### PR TITLE
Some small features

### DIFF
--- a/PluralKit.Bot/CommandMeta/CommandHelp.cs
+++ b/PluralKit.Bot/CommandMeta/CommandHelp.cs
@@ -51,7 +51,7 @@ public partial class CommandTree
     public static Command MemberServerName = new Command("member servername", "member <member> servername [server name]", "Changes a member's display name in the current server");
     public static Command MemberAutoproxy = new Command("member autoproxy", "member <member> autoproxy [on|off]", "Sets whether a member will be autoproxied when autoproxy is set to latch or front mode.");
     public static Command MemberKeepProxy = new Command("member keepproxy", "member <member> keepproxy [on|off]", "Sets whether to include a member's proxy tags when proxying");
-    public static Command MemberRandom = new Command("random", "random", "Shows the info card of a randomly selected member in your system.");
+    public static Command MemberRandom = new Command("system random", "system [system] random", "Shows the info card of a randomly selected member in a system.");
     public static Command MemberPrivacy = new Command("member privacy", "member <member> privacy <name|description|birthday|pronouns|metadata|visibility|all> <public|private>", "Changes a members's privacy settings");
     public static Command GroupInfo = new Command("group", "group <name>", "Looks up information about a group");
     public static Command GroupNew = new Command("group new", "group new <name>", "Creates a new group");
@@ -69,7 +69,7 @@ public partial class CommandTree
     public static Command GroupDelete = new Command("group delete", "group <group> delete", "Deletes a group");
     public static Command GroupFrontPercent = new Command("group frontpercent", "group <group> frontpercent [timespan]", "Shows a group's front breakdown.");
     public static Command GroupMemberRandom = new Command("group random", "group <group> random", "Shows the info card of a randomly selected member in a group.");
-    public static Command GroupRandom = new Command("random", "random group", "Shows the info card of a randomly selected group in your system.");
+    public static Command GroupRandom = new Command("system random", "system [system] random group", "Shows the info card of a randomly selected group in a system.");
     public static Command Switch = new Command("switch", "switch <member> [member 2] [member 3...]", "Registers a switch");
     public static Command SwitchOut = new Command("switch out", "switch out", "Registers a switch with no members");
     public static Command SwitchMove = new Command("switch move", "switch move <date/time>", "Moves the latest switch in time");

--- a/PluralKit.Bot/CommandMeta/CommandHelp.cs
+++ b/PluralKit.Bot/CommandMeta/CommandHelp.cs
@@ -19,6 +19,7 @@ public partial class CommandTree
     public static Command SystemFronter = new Command("system fronter", "system [system] fronter", "Shows a system's fronter(s)");
     public static Command SystemFrontHistory = new Command("system fronthistory", "system [system] fronthistory", "Shows a system's front history");
     public static Command SystemFrontPercent = new Command("system frontpercent", "system [system] frontpercent [timespan]", "Shows a system's front breakdown");
+    public static Command SystemId = new Command("system id", "system [system] id", "Prints your system's id.");
     public static Command SystemPrivacy = new Command("system privacy", "system [system] privacy <description|members|fronter|fronthistory|all> <public|private>", "Changes your system's privacy settings");
     public static Command ConfigTimezone = new Command("config timezone", "config timezone [timezone]", "Changes your system's time zone");
     public static Command ConfigPing = new Command("config ping", "config ping [on|off]", "Changes your system's ping preferences");
@@ -52,6 +53,7 @@ public partial class CommandTree
     public static Command MemberAutoproxy = new Command("member autoproxy", "member <member> autoproxy [on|off]", "Sets whether a member will be autoproxied when autoproxy is set to latch or front mode.");
     public static Command MemberKeepProxy = new Command("member keepproxy", "member <member> keepproxy [on|off]", "Sets whether to include a member's proxy tags when proxying");
     public static Command MemberRandom = new Command("system random", "system [system] random", "Shows the info card of a randomly selected member in a system.");
+    public static Command MemberId = new Command("member id", "member [member] id", "Prints a member's id.");
     public static Command MemberPrivacy = new Command("member privacy", "member <member> privacy <name|description|birthday|pronouns|metadata|visibility|all> <public|private>", "Changes a members's privacy settings");
     public static Command GroupInfo = new Command("group", "group <name>", "Looks up information about a group");
     public static Command GroupNew = new Command("group new", "group new <name>", "Creates a new group");
@@ -63,6 +65,7 @@ public partial class CommandTree
     public static Command GroupColor = new Command("group color", "group <group> color [color]", "Changes a group's color");
     public static Command GroupAdd = new Command("group add", "group <group> add <member> [member 2] [member 3...]", "Adds one or more members to a group");
     public static Command GroupRemove = new Command("group remove", "group <group> remove <member> [member 2] [member 3...]", "Removes one or more members from a group");
+    public static Command GroupId = new Command("group id", "group [group] id", "Prints a group's id.");
     public static Command GroupPrivacy = new Command("group privacy", "group <group> privacy <name|description|icon|metadata|visibility|all> <public|private>", "Changes a group's privacy settings");
     public static Command GroupBannerImage = new Command("group banner", "group <group> banner [url]", "Set the group's banner image");
     public static Command GroupIcon = new Command("group icon", "group <group> icon [url|@mention]", "Changes a group's icon");

--- a/PluralKit.Bot/CommandMeta/CommandTree.cs
+++ b/PluralKit.Bot/CommandMeta/CommandTree.cs
@@ -100,9 +100,9 @@ public partial class CommandTree
             return HandleAdminCommand(ctx);
         if (ctx.Match("random", "r"))
             if (ctx.Match("group", "g") || ctx.MatchFlag("group", "g"))
-                return ctx.Execute<Random>(GroupRandom, r => r.Group(ctx));
+                return ctx.Execute<Random>(GroupRandom, r => r.Group(ctx, ctx.System));
             else
-                return ctx.Execute<Random>(MemberRandom, m => m.Member(ctx));
+                return ctx.Execute<Random>(MemberRandom, m => m.Member(ctx, ctx.System));
 
         // remove compiler warning
         return ctx.Reply(
@@ -250,6 +250,11 @@ public partial class CommandTree
             await ctx.CheckSystem(target).Execute<SystemEdit>(SystemPrivacy, m => m.SystemPrivacy(ctx, target));
         else if (ctx.Match("delete", "remove", "destroy", "erase", "yeet"))
             await ctx.CheckSystem(target).Execute<SystemEdit>(SystemDelete, m => m.Delete(ctx, target));
+        else if (ctx.Match("random", "r"))
+            if (ctx.Match("group", "g") || ctx.MatchFlag("group", "g"))
+                await ctx.CheckSystem(target).Execute<Random>(GroupRandom, r => r.Group(ctx, target));
+            else
+                await ctx.CheckSystem(target).Execute<Random>(MemberRandom, m => m.Member(ctx, target));
     }
 
     private async Task HandleMemberCommand(Context ctx)

--- a/PluralKit.Bot/CommandMeta/CommandTree.cs
+++ b/PluralKit.Bot/CommandMeta/CommandTree.cs
@@ -250,6 +250,8 @@ public partial class CommandTree
             await ctx.CheckSystem(target).Execute<SystemEdit>(SystemPrivacy, m => m.SystemPrivacy(ctx, target));
         else if (ctx.Match("delete", "remove", "destroy", "erase", "yeet"))
             await ctx.CheckSystem(target).Execute<SystemEdit>(SystemDelete, m => m.Delete(ctx, target));
+        else if (ctx.Match("id"))
+            await ctx.CheckSystem(target).Execute<System>(SystemId, m => m.DisplayId(ctx, target));
         else if (ctx.Match("random", "r"))
             if (ctx.Match("group", "g") || ctx.MatchFlag("group", "g"))
                 await ctx.CheckSystem(target).Execute<Random>(GroupRandom, r => r.Group(ctx, target));
@@ -317,6 +319,8 @@ public partial class CommandTree
             await ctx.Execute<MemberEdit>(MemberAutoproxy, m => m.MemberAutoproxy(ctx, target));
         else if (ctx.Match("keepproxy", "keeptags", "showtags", "kp"))
             await ctx.Execute<MemberEdit>(MemberKeepProxy, m => m.KeepProxy(ctx, target));
+        else if (ctx.Match("id"))
+            await ctx.Execute<Member>(MemberId, m => m.DisplayId(ctx, target));
         else if (ctx.Match("privacy"))
             await ctx.Execute<MemberEdit>(MemberPrivacy, m => m.Privacy(ctx, target, null));
         else if (ctx.Match("private", "hidden", "hide"))
@@ -377,6 +381,8 @@ public partial class CommandTree
                 await ctx.Execute<SystemFront>(GroupFrontPercent, g => g.FrontPercent(ctx, group: target));
             else if (ctx.Match("color", "colour"))
                 await ctx.Execute<Groups>(GroupColor, g => g.GroupColor(ctx, target));
+            else if (ctx.Match("id"))
+                await ctx.Execute<Groups>(GroupId, g => g.DisplayId(ctx, target));
             else if (!ctx.HasNext())
                 await ctx.Execute<Groups>(GroupInfo, g => g.ShowGroupCard(ctx, target));
             else

--- a/PluralKit.Bot/Commands/Groups.cs
+++ b/PluralKit.Bot/Commands/Groups.cs
@@ -159,7 +159,8 @@ public class Groups
                         + $"To clear it, type `pk;group {reference} displayname -clear`."
                         + $"To print the raw display name, type `pk;group {reference} displayname -raw`.");
 
-                eb.Footer(new Embed.EmbedFooter($"Using {target.DisplayName.Length}/{Limits.MaxGroupNameLength} characters."));
+                if (ctx.System?.Id == target.System)
+                    eb.Footer(new Embed.EmbedFooter($"Using {target.DisplayName.Length}/{Limits.MaxGroupNameLength} characters."));
 
                 await ctx.Reply(embed: eb.Build());
             }
@@ -579,7 +580,7 @@ public class Groups
 
     public async Task DisplayId(Context ctx, PKGroup target)
     {
-        await ctx.Reply($"{target.Hid}");
+        await ctx.Reply(target.Hid);
     }
 
     private async Task<PKSystem> GetGroupSystem(Context ctx, PKGroup target)

--- a/PluralKit.Bot/Commands/Groups.cs
+++ b/PluralKit.Bot/Commands/Groups.cs
@@ -577,6 +577,11 @@ public class Groups
         await ctx.Reply($"{Emojis.Success} Group deleted.");
     }
 
+    public async Task DisplayId(Context ctx, PKGroup target)
+    {
+        await ctx.Reply($"{target.Hid}");
+    }
+
     private async Task<PKSystem> GetGroupSystem(Context ctx, PKGroup target)
     {
         var system = ctx.System;

--- a/PluralKit.Bot/Commands/Groups.cs
+++ b/PluralKit.Bot/Commands/Groups.cs
@@ -118,7 +118,7 @@ public class Groups
 
         await ctx.Repository.UpdateGroup(target.Id, new GroupPatch { Name = newName });
 
-        await ctx.Reply($"{Emojis.Success} Group name changed from **{target.Name}** to **{newName}**.");
+        await ctx.Reply($"{Emojis.Success} Group name changed from **{target.Name}** to **{newName}** (using {newName.Length}/{Limits.MaxGroupNameLength} characters).");
     }
 
     public async Task GroupDisplayName(Context ctx, PKGroup target)
@@ -159,6 +159,8 @@ public class Groups
                         + $"To clear it, type `pk;group {reference} displayname -clear`."
                         + $"To print the raw display name, type `pk;group {reference} displayname -raw`.");
 
+                eb.Footer(new Embed.EmbedFooter($"Using {target.DisplayName.Length}/{Limits.MaxGroupNameLength} characters."));
+
                 await ctx.Reply(embed: eb.Build());
             }
 
@@ -183,7 +185,7 @@ public class Groups
             var patch = new GroupPatch { DisplayName = Partial<string>.Present(newDisplayName) };
             await ctx.Repository.UpdateGroup(target.Id, patch);
 
-            await ctx.Reply($"{Emojis.Success} Group display name changed.");
+            await ctx.Reply($"{Emojis.Success} Group display name changed (using {newDisplayName.Length}/{Limits.MaxGroupNameLength} characters).");
         }
     }
 
@@ -217,7 +219,8 @@ public class Groups
                         $"To print the description with formatting, type `pk;group {target.Reference(ctx)} description -raw`."
                         + (ctx.System?.Id == target.System
                             ? $" To clear it, type `pk;group {target.Reference(ctx)} description -clear`."
-                            : "")))
+                            : "")
+                            + $" Using {target.Description.Length}/{Limits.MaxDescriptionLength} characters."))
                     .Build());
             return;
         }
@@ -239,7 +242,7 @@ public class Groups
             var patch = new GroupPatch { Description = Partial<string>.Present(description) };
             await ctx.Repository.UpdateGroup(target.Id, patch);
 
-            await ctx.Reply($"{Emojis.Success} Group description changed.");
+            await ctx.Reply($"{Emojis.Success} Group description changed (using {description.Length}/{Limits.MaxDescriptionLength} characters).");
         }
     }
 

--- a/PluralKit.Bot/Commands/Member.cs
+++ b/PluralKit.Bot/Commands/Member.cs
@@ -140,4 +140,9 @@ public class Member
             .Description($"*{scream}*");
         await ctx.Reply(embed: eb.Build());
     }
+
+    public async Task DisplayId(Context ctx, PKMember target)
+    {
+        await ctx.Reply($"{target.Hid}");
+    }
 }

--- a/PluralKit.Bot/Commands/Member.cs
+++ b/PluralKit.Bot/Commands/Member.cs
@@ -143,6 +143,6 @@ public class Member
 
     public async Task DisplayId(Context ctx, PKMember target)
     {
-        await ctx.Reply($"{target.Hid}");
+        await ctx.Reply(target.Hid);
     }
 }

--- a/PluralKit.Bot/Commands/MemberEdit.cs
+++ b/PluralKit.Bot/Commands/MemberEdit.cs
@@ -336,7 +336,7 @@ public class MemberEdit
             .Title("Member names")
             .Footer(new Embed.EmbedFooter(
                 $"Member ID: {target.Hid} | Active name in bold. Server name overrides display name, which overrides base name."
-                + (target.DisplayName != null ? $" Using {target.DisplayName.Length}/{Limits.MaxMemberNameLength} characters for the display name." : "")
+                + (target.DisplayName != null && ctx.System?.Id == target.System ? $" Using {target.DisplayName.Length}/{Limits.MaxMemberNameLength} characters for the display name." : "")
                 + (memberGuildConfig?.DisplayName != null ? $" Using {memberGuildConfig?.DisplayName.Length}/{Limits.MaxMemberNameLength} characters for the server name." : "")));
 
         var showDisplayName = target.NamePrivacy.CanAccess(lcx);

--- a/PluralKit.Bot/Commands/MemberEdit.cs
+++ b/PluralKit.Bot/Commands/MemberEdit.cs
@@ -42,7 +42,7 @@ public class MemberEdit
         var patch = new MemberPatch { Name = Partial<string>.Present(newName) };
         await ctx.Repository.UpdateMember(target.Id, patch);
 
-        await ctx.Reply($"{Emojis.Success} Member renamed.");
+        await ctx.Reply($"{Emojis.Success} Member renamed (using {newName.Length}/{Limits.MaxMemberNameLength} characters).");
         if (newName.Contains(" "))
             await ctx.Reply(
                 $"{Emojis.Note} Note that this member's name now contains spaces. You will need to surround it with \"double quotes\" when using commands referring to it.");
@@ -89,7 +89,8 @@ public class MemberEdit
                         $"To print the description with formatting, type `pk;member {target.Reference(ctx)} description -raw`."
                         + (ctx.System?.Id == target.System
                             ? $" To clear it, type `pk;member {target.Reference(ctx)} description -clear`."
-                            : "")))
+                            : "")
+                        + $" Using {target.Description.Length}/{Limits.MaxDescriptionLength} characters."))
                     .Build());
             return;
         }
@@ -111,7 +112,7 @@ public class MemberEdit
             var patch = new MemberPatch { Description = Partial<string>.Present(description) };
             await ctx.Repository.UpdateMember(target.Id, patch);
 
-            await ctx.Reply($"{Emojis.Success} Member description changed.");
+            await ctx.Reply($"{Emojis.Success} Member description changed (using {description.Length}/{Limits.MaxDescriptionLength} characters).");
         }
     }
 
@@ -141,7 +142,8 @@ public class MemberEdit
                     $"**{target.NameFor(ctx)}**'s pronouns are **{target.Pronouns}**.\nTo print the pronouns with formatting, type `pk;member {target.Reference(ctx)} pronouns -raw`."
                     + (ctx.System?.Id == target.System
                         ? $" To clear them, type `pk;member {target.Reference(ctx)} pronouns -clear`."
-                        : ""));
+                        : "")
+                    + $" Using {target.Pronouns.Length}/{Limits.MaxPronounsLength} characters.");
             return;
         }
 
@@ -162,7 +164,7 @@ public class MemberEdit
             var patch = new MemberPatch { Pronouns = Partial<string>.Present(pronouns) };
             await ctx.Repository.UpdateMember(target.Id, patch);
 
-            await ctx.Reply($"{Emojis.Success} Member pronouns changed.");
+            await ctx.Reply($"{Emojis.Success} Member pronouns changed (using {pronouns.Length}/{Limits.MaxPronounsLength} characters).");
         }
     }
 
@@ -333,7 +335,9 @@ public class MemberEdit
         var eb = new EmbedBuilder()
             .Title("Member names")
             .Footer(new Embed.EmbedFooter(
-                $"Member ID: {target.Hid} | Active name in bold. Server name overrides display name, which overrides base name."));
+                $"Member ID: {target.Hid} | Active name in bold. Server name overrides display name, which overrides base name."
+                + (target.DisplayName != null ? $" Using {target.DisplayName.Length}/{Limits.MaxMemberNameLength} characters for the display name." : "")
+                + (memberGuildConfig?.DisplayName != null ? $" Using {memberGuildConfig?.DisplayName.Length}/{Limits.MaxMemberNameLength} characters for the server name." : "")));
 
         var showDisplayName = target.NamePrivacy.CanAccess(lcx);
 
@@ -423,7 +427,7 @@ public class MemberEdit
             await ctx.Repository.UpdateMember(target.Id, patch);
 
             await PrintSuccess(
-                $"{Emojis.Success} Member display name changed. This member will now be proxied using the name \"{newDisplayName}\".");
+                $"{Emojis.Success} Member display name changed (using {newDisplayName.Length}/{Limits.MaxMemberNameLength} characters). This member will now be proxied using the name \"{newDisplayName}\".");
         }
     }
 
@@ -480,7 +484,7 @@ public class MemberEdit
                 new MemberGuildPatch { DisplayName = newServerName });
 
             await ctx.Reply(
-                $"{Emojis.Success} Member server name changed. This member will now be proxied using the name \"{newServerName}\" in this server ({ctx.Guild.Name}).");
+                $"{Emojis.Success} Member server name changed (using {newServerName.Length}/{Limits.MaxMemberNameLength} characters). This member will now be proxied using the name \"{newServerName}\" in this server ({ctx.Guild.Name}).");
         }
     }
 

--- a/PluralKit.Bot/Commands/MemberProxy.cs
+++ b/PluralKit.Bot/Commands/MemberProxy.cs
@@ -79,7 +79,7 @@ public class MemberProxy
             var patch = new MemberPatch { ProxyTags = Partial<ProxyTag[]>.Present(newTags.ToArray()) };
             await ctx.Repository.UpdateMember(target.Id, patch);
 
-            await ctx.Reply($"{Emojis.Success} Added proxy tags {tagToAdd.ProxyString.AsCode()}.");
+            await ctx.Reply($"{Emojis.Success} Added proxy tags {tagToAdd.ProxyString.AsCode()} (using {tagToAdd.ProxyString.Length}/{Limits.MaxProxyTagLength} characters).");
         }
         // Subcommand: "remove"
         else if (ctx.Match("remove", "delete"))
@@ -121,7 +121,7 @@ public class MemberProxy
             var patch = new MemberPatch { ProxyTags = Partial<ProxyTag[]>.Present(newTags) };
             await ctx.Repository.UpdateMember(target.Id, patch);
 
-            await ctx.Reply($"{Emojis.Success} Member proxy tags set to {requestedTag.ProxyString.AsCode()}.");
+            await ctx.Reply($"{Emojis.Success} Member proxy tags set to {requestedTag.ProxyString.AsCode()} (using {requestedTag.ProxyString.Length}/{Limits.MaxProxyTagLength} characters).");
         }
     }
 }

--- a/PluralKit.Bot/Commands/Random.cs
+++ b/PluralKit.Bot/Commands/Random.cs
@@ -15,48 +15,58 @@ public class Random
 
     // todo: get postgresql to return one random member/group instead of querying all members/groups
 
-    public async Task Member(Context ctx)
+    public async Task Member(Context ctx, PKSystem target)
     {
-        ctx.CheckSystem();
+        if (target == null)
+            throw Errors.NoSystemError;
 
-        var members = await ctx.Repository.GetSystemMembers(ctx.System.Id).ToListAsync();
+        ctx.CheckSystemPrivacy(target.Id, target.MemberListPrivacy);
+
+        var members = await ctx.Repository.GetSystemMembers(target.Id).ToListAsync();
 
         if (!ctx.MatchFlag("all", "a"))
             members = members.Where(m => m.MemberVisibility == PrivacyLevel.Public).ToList();
+        else
+            ctx.CheckOwnSystem(target);
 
         if (members == null || !members.Any())
             throw new PKError(
                 "Your system has no members! Please create at least one member before using this command.");
 
         var randInt = randGen.Next(members.Count);
-        await ctx.Reply(embed: await _embeds.CreateMemberEmbed(ctx.System, members[randInt], ctx.Guild,
-            ctx.LookupContextFor(ctx.System.Id), ctx.Zone));
+        await ctx.Reply(embed: await _embeds.CreateMemberEmbed(target, members[randInt], ctx.Guild,
+            ctx.LookupContextFor(target.Id), ctx.Zone));
     }
 
-    public async Task Group(Context ctx)
+    public async Task Group(Context ctx, PKSystem target)
     {
-        ctx.CheckSystem();
+        if (target == null)
+            throw Errors.NoSystemError;
+        
+        ctx.CheckSystemPrivacy(target.Id, target.GroupListPrivacy);
 
-        var groups = await ctx.Repository.GetSystemGroups(ctx.System.Id).ToListAsync();
+        var groups = await ctx.Repository.GetSystemGroups(target.Id).ToListAsync();
         if (!ctx.MatchFlag("all", "a"))
             groups = groups.Where(g => g.Visibility == PrivacyLevel.Public).ToList();
+        else
+            ctx.CheckOwnSystem(target);
 
         if (groups == null || !groups.Any())
             throw new PKError(
                 "Your system has no groups! Please create at least one group before using this command.");
 
         var randInt = randGen.Next(groups.Count());
-        await ctx.Reply(embed: await _embeds.CreateGroupEmbed(ctx, ctx.System, groups.ToArray()[randInt]));
+        await ctx.Reply(embed: await _embeds.CreateGroupEmbed(ctx, target, groups.ToArray()[randInt]));
     }
 
     public async Task GroupMember(Context ctx, PKGroup group)
     {
-        ctx.CheckOwnGroup(group);
+        ctx.CheckSystemPrivacy(group.System, group.ListPrivacy);
 
         var opts = ctx.ParseListOptions(ctx.DirectLookupContextFor(group.System));
         opts.GroupFilter = group.Id;
 
-        var members = await ctx.Database.Execute(conn => conn.QueryMemberList(ctx.System.Id, opts.ToQueryOptions()));
+        var members = await ctx.Database.Execute(conn => conn.QueryMemberList(group.System, opts.ToQueryOptions()));
 
         if (members == null || !members.Any())
             throw new PKError(
@@ -64,11 +74,20 @@ public class Random
 
         if (!ctx.MatchFlag("all", "a"))
             members = members.Where(g => g.MemberVisibility == PrivacyLevel.Public);
+        else
+            ctx.CheckOwnGroup(group);
+
 
         var ms = members.ToList();
 
+        PKSystem system;
+        if (ctx.System?.Id == group.System)
+            system = ctx.System;
+        else
+            system = await ctx.Repository.GetSystem(group.System);
+
         var randInt = randGen.Next(ms.Count);
-        await ctx.Reply(embed: await _embeds.CreateMemberEmbed(ctx.System, ms[randInt], ctx.Guild,
-            ctx.LookupContextFor(ctx.System.Id), ctx.Zone));
+        await ctx.Reply(embed: await _embeds.CreateMemberEmbed(system, ms[randInt], ctx.Guild,
+            ctx.LookupContextFor(group.System), ctx.Zone));
     }
 }

--- a/PluralKit.Bot/Commands/Random.cs
+++ b/PluralKit.Bot/Commands/Random.cs
@@ -31,7 +31,9 @@ public class Random
 
         if (members == null || !members.Any())
             throw new PKError(
-                "Your system has no members! Please create at least one member before using this command.");
+                ctx.System?.Id == target.Id ?
+                "Your system has no members! Please create at least one member before using this command." :
+                "This system has no members!");
 
         var randInt = randGen.Next(members.Count);
         await ctx.Reply(embed: await _embeds.CreateMemberEmbed(target, members[randInt], ctx.Guild,
@@ -53,7 +55,9 @@ public class Random
 
         if (groups == null || !groups.Any())
             throw new PKError(
-                "Your system has no groups! Please create at least one group before using this command.");
+                ctx.System?.Id == target.Id ? 
+                    "Your system has no groups! Please create at least one group before using this command." : 
+                    $"This system has no groups!");
 
         var randInt = randGen.Next(groups.Count());
         await ctx.Reply(embed: await _embeds.CreateGroupEmbed(ctx, target, groups.ToArray()[randInt]));
@@ -70,7 +74,8 @@ public class Random
 
         if (members == null || !members.Any())
             throw new PKError(
-                "This group has no members! Please add at least one member to this group before using this command.");
+                "This group has no members!"
+                + ( ctx.System?.Id == group.System ? " Please add at least one member to this group before using this command." : ""));
 
         if (!ctx.MatchFlag("all", "a"))
             members = members.Where(g => g.MemberVisibility == PrivacyLevel.Public);

--- a/PluralKit.Bot/Commands/System.cs
+++ b/PluralKit.Bot/Commands/System.cs
@@ -39,6 +39,6 @@ public class System
         if (target == null)
             throw Errors.NoSystemError;
 
-        await ctx.Reply($"{target.Hid}");
+        await ctx.Reply(target.Hid);
     }
 }

--- a/PluralKit.Bot/Commands/System.cs
+++ b/PluralKit.Bot/Commands/System.cs
@@ -33,4 +33,12 @@ public class System
         await ctx.Reply(
             $"{Emojis.Success} Your system has been created. Type `pk;system` to view it, and type `pk;system help` for more information about commands you can use now. Now that you have that set up, check out the getting started guide on setting up members and proxies: <https://pluralkit.me/start>");
     }
+
+    public async Task DisplayId(Context ctx, PKSystem target)
+    {
+        if (target == null)
+            throw Errors.NoSystemError;
+
+        await ctx.Reply($"{target.Hid}");
+    }
 }

--- a/PluralKit.Bot/Commands/SystemEdit.cs
+++ b/PluralKit.Bot/Commands/SystemEdit.cs
@@ -48,7 +48,8 @@ public class SystemEdit
             if (target.Name != null)
                 await ctx.Reply(
                     $"{(isOwnSystem ? "Your" : "This")} system's name is currently **{target.Name}**."
-                    + (isOwnSystem ? " Type `pk;system name -clear` to clear it." : ""));
+                    + (isOwnSystem ? " Type `pk;system name -clear` to clear it." : "")
+                    + $" Using {target.Name.Length}/{Limits.MaxSystemNameLength} characters.");
             else
                 await ctx.Reply(noNameSetMessage);
             return;
@@ -71,7 +72,7 @@ public class SystemEdit
 
             await ctx.Repository.UpdateSystem(target.Id, new SystemPatch { Name = newSystemName });
 
-            await ctx.Reply($"{Emojis.Success} System name changed.");
+            await ctx.Reply($"{Emojis.Success} System name changed (using {newSystemName.Length}/{Limits.MaxSystemNameLength} characters).");
         }
     }
 
@@ -104,7 +105,8 @@ public class SystemEdit
                     .Description(target.Description)
                     .Footer(new Embed.EmbedFooter(
                         "To print the description with formatting, type `pk;s description -raw`."
-                            + (isOwnSystem ? "To clear it, type `pk;s description -clear`. To change it, type `pk;s description <new description>`." : "")))
+                            + (isOwnSystem ? " To clear it, type `pk;s description -clear`. To change it, type `pk;s description <new description>`." : "")
+                            + $" Using {target.Description.Length}/{Limits.MaxDescriptionLength} characters."))
                     .Build());
             return;
         }
@@ -125,7 +127,7 @@ public class SystemEdit
 
             await ctx.Repository.UpdateSystem(target.Id, new SystemPatch { Description = newDescription });
 
-            await ctx.Reply($"{Emojis.Success} System description changed.");
+            await ctx.Reply($"{Emojis.Success} System description changed (using {newDescription.Length}/{Limits.MaxDescriptionLength} characters).");
         }
     }
 
@@ -224,7 +226,7 @@ public class SystemEdit
             await ctx.Repository.UpdateSystem(target.Id, new SystemPatch { Tag = newTag });
 
             await ctx.Reply(
-                $"{Emojis.Success} System tag changed. Member names will now end with {newTag.AsCode()} when proxied.");
+                $"{Emojis.Success} System tag changed (using {newTag.Length}/{Limits.MaxSystemTagLength} characters). Member names will now end with {newTag.AsCode()} when proxied.");
         }
     }
 
@@ -275,7 +277,7 @@ public class SystemEdit
             await ctx.Repository.UpdateSystemGuild(target.Id, ctx.Guild.Id, new SystemGuildPatch { Tag = newTag });
 
             await ctx.Reply(
-                $"{Emojis.Success} System server tag changed. Member names will now end with {newTag.AsCode()} when proxied in the current server '{ctx.Guild.Name}'.");
+                $"{Emojis.Success} System server tag changed (using {newTag.Length}/{Limits.MaxSystemTagLength} characters). Member names will now end with {newTag.AsCode()} when proxied in the current server '{ctx.Guild.Name}'.");
 
             if (!settings.TagEnabled)
                 await ctx.Reply(setDisabledWarning);
@@ -375,7 +377,8 @@ public class SystemEdit
             else
                 await ctx.Reply($"{(isOwnSystem ? "Your" : "This system's")} current pronouns are **{target.Pronouns}**.\nTo print the pronouns with formatting, type `pk;system pronouns -raw`."
                 + (isOwnSystem ? " To clear them, type `pk;system pronouns -clear`."
-                : ""));
+                : "")
+                + $" Using {target.Pronouns.Length}/{Limits.MaxPronounsLength} characters.");
             return;
         }
 
@@ -397,7 +400,7 @@ public class SystemEdit
             await ctx.Repository.UpdateSystem(target.Id, new SystemPatch { Pronouns = newPronouns });
 
             await ctx.Reply(
-                $"{Emojis.Success} System pronouns changed.");
+                $"{Emojis.Success} System pronouns changed (using {newPronouns.Length}/{Limits.MaxPronounsLength} characters).");
         }
     }
 

--- a/docs/content/command-list.md
+++ b/docs/content/command-list.md
@@ -53,6 +53,7 @@ Some arguments indicate the use of specific Discord features. These include:
 - `pk;system [system] list -full` - Shows a paginated list of a system's members, with increased detail.
 - `pk;find <search term>` - Searches members by name.
 - `pk;system [system] find <search term>` - (same as above, but for a specific system)
+- `pk;system [system] random [-group]` - Shows the info card of a randomly selected member [or group] in a system.
 
 ## Member commands
 *Replace `<member>` with a member's name, 5-character ID or display name. For most commands, adding `-clear` will clear/delete the field.*
@@ -127,7 +128,6 @@ Some arguments indicate the use of specific Discord features. These include:
 - `pk;blacklist remove <#channel> [#channel...]` - Removes the given channel(s) from the proxy blacklist.
 
 ## Utility
-- `pk;random [-group]` - Shows the info card of a randomly selected member [or group] in your system.
 - `pk;message <message id|message link|reply>` - Looks up information about a proxied message by its message ID or link.
 - `pk;invite` - Sends the bot invite link for PluralKit.
 - `pk;import` - Imports a data file from PluralKit or Tupperbox.

--- a/docs/content/command-list.md
+++ b/docs/content/command-list.md
@@ -54,6 +54,7 @@ Some arguments indicate the use of specific Discord features. These include:
 - `pk;find <search term>` - Searches members by name.
 - `pk;system [system] find <search term>` - (same as above, but for a specific system)
 - `pk;system [system] random [-group]` - Shows the info card of a randomly selected member [or group] in a system.
+- `pk;system [system] id` - Prints a system's id. 
 
 ## Member commands
 *Replace `<member>` with a member's name, 5-character ID or display name. For most commands, adding `-clear` will clear/delete the field.*
@@ -77,6 +78,7 @@ Some arguments indicate the use of specific Discord features. These include:
 - `pk;member <member> color [color]` - Changes the color of a member.
 - `pk;member <member> birthdate [birthdate|today]` - Changes the birthday of a member.
 - `pk;member <member> delete` - Deletes a member.
+- `pk;member <member> id` - Prints a member's id. 
 
 ## Group commands
 *Replace `<group>` with a group's name, 5-character ID or display name. For most commands, adding `-clear` will clear/delete the field.*
@@ -94,6 +96,7 @@ Some arguments indicate the use of specific Discord features. These include:
 - `pk;group <group> icon [icon url|@mention|upload]` - Shows or changes a group's icon.
 - `pk;group <group> banner [image url|upload]` - Shows or changes a group's banner image.
 - `pk;group <group> delete` - Deletes a group.
+- `pk;group <group> id` - Prints a group's id. 
 
 ## Switching commands
 - `pk;switch [member...]` - Registers a switch with the given members.


### PR DESCRIPTION
Three main things have been added here:
- added displaying the amount of characters a string field takes up. both when setting it, and when pulling up that field's information.
- allow `pk;random` for other systems. (using `pk;s system random`). because a `pk;s` variation of the command has been added, documentation has changed to show the `pk;s random` variant over `pk;random`. but `pk;random` will still work as a command.
- added a command for systems, members and groups that just prints the raw id of that item, no formatting.

I tried to include docs as thoroughly as possible but it's possible I might've missed something. I'm also not sure about the id commands *only* printing the id, nothing else, as it might be confusing. But I left it as is in case it's fine.