### PR TITLE
fix(bot): Proxy tag size limit

### DIFF
--- a/PluralKit.Bot/Commands/MemberProxy.cs
+++ b/PluralKit.Bot/Commands/MemberProxy.cs
@@ -17,6 +17,8 @@ public class MemberProxy
             if (prefixAndSuffix.Length == 1) prefixAndSuffix = prefixAndSuffix[0].Split("TEXT");
             if (prefixAndSuffix.Length < 2) throw Errors.ProxyMustHaveText;
             if (prefixAndSuffix.Length > 2) throw Errors.ProxyMultipleText;
+            if (prefixAndSuffix[0].length > 64) throw Errors.ProxyTooBig;
+            if (prefixAndSuffix[1].length > 64) throw Errors.ProxyTooBig;
             return new ProxyTag(prefixAndSuffix[0], prefixAndSuffix[1]);
         }
 

--- a/PluralKit.Bot/Errors.cs
+++ b/PluralKit.Bot/Errors.cs
@@ -50,6 +50,9 @@ public static class Errors
 
     public static PKError ProxyMultipleText =>
         new PKSyntaxError("Example proxy message must contain the string 'text' exactly once.");
+    
+    public static PKError ProxyTooBig =>
+        new PKSyntaxError("Given proxy tag contains too many characters.");
 
     public static PKError MemberDeleteCancelled => new($"Member deletion cancelled. Stay safe! {Emojis.ThumbsUp}");
 


### PR DESCRIPTION
Having a proxy tag that's too big causes the bot to throw an error, I went in and created a size limit of 64 for prefix and suffix separately, as that sounded reasonable.