### PR TITLE
feat(bot): change message count sorting

### DIFF
--- a/PluralKit.Bot/Commands/Lists/ListOptions.cs
+++ b/PluralKit.Bot/Commands/Lists/ListOptions.cs
@@ -122,7 +122,7 @@ public static class ListOptionsExt
                 .OrderByDescending(m => m.MetadataPrivacy.CanAccess(ctx))
                 .ThenBy(m => m.MetadataPrivacy.Get(ctx, m.Created, default), ReverseMaybe(Comparer<Instant>.Default)),
             SortProperty.MessageCount => input
-                .OrderByDescending(m => m.MessageCount != 0 && m.MetadataPrivacy.CanAccess(ctx))
+                .OrderByDescending(m => m.MetadataPrivacy.CanAccess(ctx))
                 .ThenByDescending(m => m.MetadataPrivacy.Get(ctx, m.MessageCount, 0), ReverseMaybe(Comparer<int>.Default)),
             SortProperty.DisplayName => input
                 .OrderByDescending(m => m.DisplayName != null && m.NamePrivacy.CanAccess(ctx))


### PR DESCRIPTION
It was pointed out [in the suggestions channel](https://discord.com/channels/466707357099884544/468821582794588160/1065730322379051028) that when sorting with -bmc -r putting members that have 0 messages at the end of the list (where null values go) is uninuitive and it would make more sense to have it at the beginning of the list where it fits in the numerical order instead of being displaced to the end. 
I don't know if the developers agree with this change but I figured since it was an easy PR it wouldn't hurt. 