### PR TITLE
CORS: Allow custom UAs

### DIFF
--- a/services/web-proxy/main.go
+++ b/services/web-proxy/main.go
@@ -67,7 +67,7 @@ func (p ProxyHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		rw.Header().Add("Access-Control-Allow-Origin", "*")
 		rw.Header().Add("Access-Control-Allow-Methods", "*")
 		rw.Header().Add("Access-Control-Allow-Credentials", "true")
-		rw.Header().Add("Access-Control-Allow-Headers", "Content-Type, Authorization, sentry-trace")
+		rw.Header().Add("Access-Control-Allow-Headers", "Content-Type, Authorization, sentry-trace", "User-Agent")
 		rw.Header().Add("Access-Control-Max-Age", "86400")
 
 		if r.Method == http.MethodOptions {


### PR DESCRIPTION
Firefox's (correct) CORS implementation considers `User-Agent` as a forbidden header and requires the server to explicitly opt into custom UAs by allowing this header in `Access-Control-Allow-Headers`.

This pull request does that change. It enables CSR apps to correctly communicate which tools they are part of.