### PR TITLE
feat(bot): allow separate member avatars for proxied messages

### DIFF
--- a/PluralKit.Bot/CommandMeta/CommandTree.cs
+++ b/PluralKit.Bot/CommandMeta/CommandTree.cs
@@ -304,7 +304,7 @@ public partial class CommandTree
             await ctx.Execute<MemberEdit>(MemberDelete, m => m.Delete(ctx, target));
         else if (ctx.Match("avatar", "profile", "picture", "icon", "image", "pfp", "pic"))
             await ctx.Execute<MemberAvatar>(MemberAvatar, m => m.Avatar(ctx, target));
-        else if (ctx.Match("proxyavatar", "proxypfp", "webhookavatar", "webhookpfp"))
+        else if (ctx.Match("proxyavatar", "proxypfp", "webhookavatar", "webhookpfp", "pa"))
             await ctx.Execute<MemberAvatar>(MemberAvatar, m => m.WebhookAvatar(ctx, target));
         else if (ctx.Match("banner", "splash", "cover"))
             await ctx.Execute<MemberEdit>(MemberBannerImage, m => m.BannerImage(ctx, target));

--- a/PluralKit.Bot/CommandMeta/CommandTree.cs
+++ b/PluralKit.Bot/CommandMeta/CommandTree.cs
@@ -304,6 +304,8 @@ public partial class CommandTree
             await ctx.Execute<MemberEdit>(MemberDelete, m => m.Delete(ctx, target));
         else if (ctx.Match("avatar", "profile", "picture", "icon", "image", "pfp", "pic"))
             await ctx.Execute<MemberAvatar>(MemberAvatar, m => m.Avatar(ctx, target));
+        else if (ctx.Match("proxyavatar", "proxypfp", "webhookavatar", "webhookpfp"))
+            await ctx.Execute<MemberAvatar>(MemberAvatar, m => m.WebhookAvatar(ctx, target));
         else if (ctx.Match("banner", "splash", "cover"))
             await ctx.Execute<MemberEdit>(MemberBannerImage, m => m.BannerImage(ctx, target));
         else if (ctx.Match("group", "groups"))

--- a/PluralKit.Bot/Services/EmbedService.cs
+++ b/PluralKit.Bot/Services/EmbedService.cs
@@ -135,7 +135,7 @@ public class EmbedService
         // sometimes Discord will just... not return the avatar hash with webhook messages
         var avatar = proxiedMessage.Author.Avatar != null
             ? proxiedMessage.Author.AvatarUrl()
-            : member.AvatarFor(LookupContext.ByNonOwner);
+            : member.AvatarFor(LookupContext.ByNonOwner, true);
         var embed = new EmbedBuilder()
             .Author(new Embed.EmbedAuthor($"#{channelName}: {name}", IconUrl: avatar))
             .Thumbnail(new Embed.EmbedThumbnail(avatar))
@@ -175,7 +175,8 @@ public class EmbedService
 
         var guildSettings = guild != null ? await _repo.GetMemberGuild(guild.Id, member.Id) : null;
         var guildDisplayName = guildSettings?.DisplayName;
-        var avatar = guildSettings?.AvatarUrl ?? member.AvatarFor(ctx);
+        var webhook_avatar = guildSettings?.AvatarUrl ?? member.AvatarFor(ctx, true) ?? member.AvatarFor(ctx, false);
+        var avatar = guildSettings?.AvatarUrl ?? member.AvatarFor(ctx, false);
 
         var groups = await _repo.GetMemberGroups(member.Id)
             .Where(g => g.Visibility.CanAccess(ctx))
@@ -183,7 +184,7 @@ public class EmbedService
             .ToListAsync();
 
         var eb = new EmbedBuilder()
-            .Author(new Embed.EmbedAuthor(name, IconUrl: avatar.TryGetCleanCdnUrl(), Url: $"https://dash.pluralkit.me/profile/m/{member.Hid}"))
+            .Author(new Embed.EmbedAuthor(name, IconUrl: webhook_avatar.TryGetCleanCdnUrl(), Url: $"https://dash.pluralkit.me/profile/m/{member.Hid}"))
             // .WithColor(member.ColorPrivacy.CanAccess(ctx) ? color : DiscordUtils.Gray)
             .Color(color)
             .Footer(new Embed.EmbedFooter(

--- a/PluralKit.Bot/Services/EmbedService.cs
+++ b/PluralKit.Bot/Services/EmbedService.cs
@@ -135,7 +135,7 @@ public class EmbedService
         // sometimes Discord will just... not return the avatar hash with webhook messages
         var avatar = proxiedMessage.Author.Avatar != null
             ? proxiedMessage.Author.AvatarUrl()
-            : member.AvatarFor(LookupContext.ByNonOwner, true);
+            : member.WebhookAvatarFor(LookupContext.ByNonOwner);
         var embed = new EmbedBuilder()
             .Author(new Embed.EmbedAuthor($"#{channelName}: {name}", IconUrl: avatar))
             .Thumbnail(new Embed.EmbedThumbnail(avatar))
@@ -175,8 +175,8 @@ public class EmbedService
 
         var guildSettings = guild != null ? await _repo.GetMemberGuild(guild.Id, member.Id) : null;
         var guildDisplayName = guildSettings?.DisplayName;
-        var webhook_avatar = guildSettings?.AvatarUrl ?? member.AvatarFor(ctx, true) ?? member.AvatarFor(ctx, false);
-        var avatar = guildSettings?.AvatarUrl ?? member.AvatarFor(ctx, false);
+        var webhook_avatar = guildSettings?.AvatarUrl ?? member.WebhookAvatarFor(ctx) ?? member.AvatarFor(ctx);
+        var avatar = guildSettings?.AvatarUrl ?? member.AvatarFor(ctx);
 
         var groups = await _repo.GetMemberGroups(member.Id)
             .Where(g => g.Visibility.CanAccess(ctx))

--- a/PluralKit.Core/Database/Functions/ProxyMember.cs
+++ b/PluralKit.Core/Database/Functions/ProxyMember.cs
@@ -23,8 +23,8 @@ public class ProxyMember
     public string Name { get; } = "";
 
     public string? ServerAvatar { get; }
+    public string? WebhookAvatar { get; }
     public string? Avatar { get; }
-
 
     public bool AllowAutoproxy { get; }
     public string? Color { get; }
@@ -42,5 +42,5 @@ public class ProxyMember
         return memberName;
     }
 
-    public string? ProxyAvatar(MessageContext ctx) => ServerAvatar ?? Avatar ?? ctx.SystemAvatar;
+    public string? ProxyAvatar(MessageContext ctx) => ServerAvatar ?? WebhookAvatar ?? Avatar ?? ctx.SystemAvatar;
 }

--- a/PluralKit.Core/Database/Functions/functions.sql
+++ b/PluralKit.Core/Database/Functions/functions.sql
@@ -1,4 +1,4 @@
-﻿create function message_context(account_id bigint, guild_id bigint, channel_id bigint)
+create function message_context(account_id bigint, guild_id bigint, channel_id bigint)
     returns table (
         system_id int,
         log_channel bigint,
@@ -67,6 +67,7 @@ create function proxy_members(account_id bigint, guild_id bigint)
         name text,
 
         server_avatar text,
+        webhook_avatar text,
         avatar text,
 
         color char(6),
@@ -76,22 +77,23 @@ create function proxy_members(account_id bigint, guild_id bigint)
 as $$
     select
         -- Basic data
-        members.id                as id,
-        members.proxy_tags        as proxy_tags,
-        members.keep_proxy        as keep_proxy,
+        members.id                   as id,
+        members.proxy_tags           as proxy_tags,
+        members.keep_proxy           as keep_proxy,
 
         -- Name info
-        member_guild.display_name as server_name,
-        members.display_name      as display_name,
-        members.name              as name,
+        member_guild.display_name    as server_name,
+        members.display_name         as display_name,
+        members.name                 as name,
 
         -- Avatar info
-        member_guild.avatar_url   as server_avatar,
-        members.avatar_url        as avatar,
+        member_guild.avatar_url      as server_avatar,
+        members.webhook_avatar_url   as webhook_avatar,
+        members.avatar_url           as avatar,
 
-        members.color             as color,
+        members.color                as color,
 
-        members.allow_autoproxy   as allow_autoproxy
+        members.allow_autoproxy      as allow_autoproxy
     from accounts
         inner join systems on systems.id = accounts.system
         inner join members on members.system = systems.id

--- a/PluralKit.Core/Database/Migrations/33.sql
+++ b/PluralKit.Core/Database/Migrations/33.sql
@@ -1,0 +1,6 @@
+-- database version 33
+-- add webhook_avatar_url to system members
+
+alter table members add column webhook_avatar_url text;
+
+update info set schema_version = 33;

--- a/PluralKit.Core/Database/Utils/DatabaseMigrator.cs
+++ b/PluralKit.Core/Database/Utils/DatabaseMigrator.cs
@@ -9,7 +9,7 @@ namespace PluralKit.Core;
 internal class DatabaseMigrator
 {
     private const string RootPath = "PluralKit.Core.Database"; // "resource path" root for SQL files
-    private const int TargetSchemaVersion = 32;
+    private const int TargetSchemaVersion = 33;
     private readonly ILogger _logger;
 
     public DatabaseMigrator(ILogger logger)

--- a/PluralKit.Core/Models/PKMember.cs
+++ b/PluralKit.Core/Models/PKMember.cs
@@ -39,6 +39,7 @@ public class PKMember
     public Guid Uuid { get; private set; }
     public SystemId System { get; private set; }
     public string Color { get; private set; }
+    public string WebhookAvatarUrl { get; private set; }
     public string AvatarUrl { get; private set; }
     public string BannerImage { get; private set; }
     public string Name { get; private set; }
@@ -87,8 +88,8 @@ public static class PKMemberExt
     public static string NameFor(this PKMember member, LookupContext ctx) =>
         member.NamePrivacy.Get(ctx, member.Name, member.DisplayName ?? member.Name);
 
-    public static string AvatarFor(this PKMember member, LookupContext ctx) =>
-        member.AvatarPrivacy.Get(ctx, member.AvatarUrl.TryGetCleanCdnUrl());
+    public static string AvatarFor(this PKMember member, LookupContext ctx, bool use_webhook_avatar = false) =>
+        member.AvatarPrivacy.Get(ctx, (use_webhook_avatar ? member.WebhookAvatarUrl ?? member.AvatarUrl : member.AvatarUrl).TryGetCleanCdnUrl());
 
     public static string DescriptionFor(this PKMember member, LookupContext ctx) =>
         member.DescriptionPrivacy.Get(ctx, member.Description);
@@ -128,6 +129,7 @@ public static class PKMemberExt
         o.Add("birthday", member.BirthdayFor(ctx)?.FormatExport());
         o.Add("pronouns", member.PronounsFor(ctx));
         o.Add("avatar_url", member.AvatarFor(ctx).TryGetCleanCdnUrl());
+        o.Add("webhook_avatar_url", member.AvatarFor(ctx, true).TryGetCleanCdnUrl());
         o.Add("banner", member.DescriptionPrivacy.Get(ctx, member.BannerImage).TryGetCleanCdnUrl());
         o.Add("description", member.DescriptionFor(ctx));
         o.Add("created", member.CreatedFor(ctx)?.FormatExport());

--- a/PluralKit.Core/Models/PKMember.cs
+++ b/PluralKit.Core/Models/PKMember.cs
@@ -88,8 +88,11 @@ public static class PKMemberExt
     public static string NameFor(this PKMember member, LookupContext ctx) =>
         member.NamePrivacy.Get(ctx, member.Name, member.DisplayName ?? member.Name);
 
-    public static string AvatarFor(this PKMember member, LookupContext ctx, bool use_webhook_avatar = false) =>
-        member.AvatarPrivacy.Get(ctx, (use_webhook_avatar ? member.WebhookAvatarUrl ?? member.AvatarUrl : member.AvatarUrl).TryGetCleanCdnUrl());
+    public static string AvatarFor(this PKMember member, LookupContext ctx) =>
+        member.AvatarPrivacy.Get(ctx, member.AvatarUrl.TryGetCleanCdnUrl());
+
+    public static string WebhookAvatarFor(this PKMember member, LookupContext ctx) =>
+        member.AvatarPrivacy.Get(ctx, (member.WebhookAvatarUrl ?? member.AvatarUrl).TryGetCleanCdnUrl());
 
     public static string DescriptionFor(this PKMember member, LookupContext ctx) =>
         member.DescriptionPrivacy.Get(ctx, member.Description);
@@ -129,7 +132,7 @@ public static class PKMemberExt
         o.Add("birthday", member.BirthdayFor(ctx)?.FormatExport());
         o.Add("pronouns", member.PronounsFor(ctx));
         o.Add("avatar_url", member.AvatarFor(ctx).TryGetCleanCdnUrl());
-        o.Add("webhook_avatar_url", member.AvatarFor(ctx, true).TryGetCleanCdnUrl());
+        o.Add("webhook_avatar_url", member.WebhookAvatarFor(ctx).TryGetCleanCdnUrl());
         o.Add("banner", member.DescriptionPrivacy.Get(ctx, member.BannerImage).TryGetCleanCdnUrl());
         o.Add("description", member.DescriptionFor(ctx));
         o.Add("created", member.CreatedFor(ctx)?.FormatExport());

--- a/PluralKit.Core/Models/Patch/MemberPatch.cs
+++ b/PluralKit.Core/Models/Patch/MemberPatch.cs
@@ -12,6 +12,7 @@ public class MemberPatch: PatchObject
     public Partial<string> Name { get; set; }
     public Partial<string> Hid { get; set; }
     public Partial<string?> DisplayName { get; set; }
+    public Partial<string?> WebhookAvatarUrl { get; set; }
     public Partial<string?> AvatarUrl { get; set; }
     public Partial<string?> BannerImage { get; set; }
     public Partial<string?> Color { get; set; }
@@ -34,6 +35,7 @@ public class MemberPatch: PatchObject
         .With("name", Name)
         .With("hid", Hid)
         .With("display_name", DisplayName)
+        .With("webhook_avatar_url", WebhookAvatarUrl)
         .With("avatar_url", AvatarUrl)
         .With("banner_image", BannerImage)
         .With("color", Color)
@@ -62,6 +64,9 @@ public class MemberPatch: PatchObject
         if (AvatarUrl.Value != null)
             AssertValid(AvatarUrl.Value, "avatar_url", Limits.MaxUriLength,
                 s => MiscUtils.TryMatchUri(s, out var avatarUri));
+        if (WebhookAvatarUrl.Value != null)
+            AssertValid(WebhookAvatarUrl.Value, "webhook_avatar_url", Limits.MaxUriLength,
+                s => MiscUtils.TryMatchUri(s, out var webhookAvatarUri));
         if (BannerImage.Value != null)
             AssertValid(BannerImage.Value, "banner", Limits.MaxUriLength,
                 s => MiscUtils.TryMatchUri(s, out var bannerUri));
@@ -93,6 +98,7 @@ public class MemberPatch: PatchObject
         if (o.ContainsKey("name")) patch.Name = o.Value<string>("name");
         if (o.ContainsKey("color")) patch.Color = o.Value<string>("color").NullIfEmpty()?.ToLower();
         if (o.ContainsKey("display_name")) patch.DisplayName = o.Value<string>("display_name").NullIfEmpty();
+        if (o.ContainsKey("webhook_avatar_url")) patch.WebhookAvatarUrl = o.Value<string>("webhook_avatar_url").NullIfEmpty();
         if (o.ContainsKey("avatar_url")) patch.AvatarUrl = o.Value<string>("avatar_url").NullIfEmpty();
         if (o.ContainsKey("banner")) patch.BannerImage = o.Value<string>("banner").NullIfEmpty();
 
@@ -177,6 +183,8 @@ public class MemberPatch: PatchObject
             o.Add("display_name", DisplayName.Value);
         if (AvatarUrl.IsPresent)
             o.Add("avatar_url", AvatarUrl.Value);
+        if (WebhookAvatarUrl.IsPresent)
+            o.Add("webhook_avatar_url", WebhookAvatarUrl.Value);
         if (BannerImage.IsPresent)
             o.Add("banner", BannerImage.Value);
         if (Color.IsPresent)

--- a/docs/content/api/models.md
+++ b/docs/content/api/models.md
@@ -46,6 +46,7 @@ Every PluralKit entity has two IDs: a short (5-character) ID and a longer UUID. 
 |birthday|?string|`YYYY-MM-DD` format, 0004 hides the year|
 |pronouns|?string|100-character-limit|
 |avatar_url|?string|256-character limit, must be a publicly-accessible URL|
+|webhook_avatar_url|?string|256-character limit, must be a publicly-accessible URL|
 |banner|?string|256-character limit, must be a publicly-accessible URL|
 |description|?string|1000-character limit|
 |created|?datetime||

--- a/docs/content/command-list.md
+++ b/docs/content/command-list.md
@@ -65,6 +65,7 @@ Some arguments indicate the use of specific Discord features. These include:
 - `pk;member <member> servername <new server name>` - Changes the display name of a member, only in the current server.
 - `pk;member <member> description [description]` - Changes the description of a member.
 - `pk;member <member> avatar [avatar url|@mention|upload]` - Changes the avatar of a member.
+- `pk;member <member> proxyavatar [avatar url|@mention|upload]` - Changes the avatar used for proxied messages sent by a member.
 - `pk;member <member> serveravatar [avatar url|@mention|upload]` - Changes the avatar of a member in a specific server.
 - `pk;member <name> banner [image url|upload]` - Changes the banner image of a member.
 - `pk;member <member> privacy` - Displays a members current privacy settings.

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -229,6 +229,13 @@ To preview the current avatar (if one is set), use the command with no arguments
     
 To clear your avatar, use the subcommand `avatar clear` (eg. `pk;member John avatar clear`).
 
+### Member proxy avatar
+If you want your member to have a different avatar for proxies messages than the one displayed on the member card, you can set a proxy avatar. To do so, use the `pk;member proxyavatar` command, in the same way as the normal avatar command above:
+
+    pk;member John avatar
+    pk;member John proxyavatar http://placebeard.it/512.jpg
+    pk;member "Craig Johnson" proxyavatar    (with an attached image)
+
 ### Member server avatar
 You can also set an avatar for a specific server. This will "override" the normal avatar, and will be used when proxying messages and looking up member cards in that server. To do so, use the `pk;member serveravatar` command, in the same way as the normal avatar command above:
 


### PR DESCRIPTION
This allows for using one avatar for the member card, and a different avatar for proxied messages - so that users can set the main avatar to a "full" version of their avatar, and the "proxy" avatar to a resized/cropped version.

<details><summary>Example screenshot</summary>

![DiscordCanary_prUHrBzmnr](https://user-images.githubusercontent.com/30218526/221988142-923ff0ab-0146-4616-9955-2100775b34de.png)

</details>
