### PR TITLE
fix(dash): Group delete prompts

### DIFF
--- a/dashboard/src/components/group/Edit.svelte
+++ b/dashboard/src/components/group/Edit.svelte
@@ -144,7 +144,7 @@
 {:else}<Button style="flex: 0" color="primary" disabled aria-label="submit edits"><Spinner size="sm"/></Button> <Button style="flex: 0" color="secondary" disabled aria-label="cancel edits">Back</Button><Button style="flex: 0; float: right;" color="danger" disabled aria-label="delete group">Delete</Button>{/if}
 <Modal size="lg" isOpen={deleteOpen} toggle={toggleDeleteModal}>
     <ModalHeader toggle={toggleDeleteModal}>
-        Delete member
+        Delete group
      </ModalHeader>
          <ModalBody>
              {#if deleteErr}<Alert color="danger">{deleteErr}</Alert>{/if}


### PR DESCRIPTION
This pull request corrects the header of the 'Delete group' dialogue on the Dashboard from erroneously saying 'Delete member' instead of 'group' as it should.