### PR TITLE
feat(bot): Switch subcommand aliases

### DIFF
--- a/PluralKit.Bot/CommandMeta/CommandTree.cs
+++ b/PluralKit.Bot/CommandMeta/CommandTree.cs
@@ -408,9 +408,9 @@ public partial class CommandTree
     {
         if (ctx.Match("out"))
             await ctx.Execute<Switch>(SwitchOut, m => m.SwitchOut(ctx));
-        else if (ctx.Match("move", "shift", "offset"))
+        else if (ctx.Match("move", "m", "shift", "offset"))
             await ctx.Execute<Switch>(SwitchMove, m => m.SwitchMove(ctx));
-        else if (ctx.Match("edit", "replace"))
+        else if (ctx.Match("edit", "e", "replace"))
             if (ctx.Match("out"))
                 await ctx.Execute<Switch>(SwitchEditOut, m => m.SwitchEditOut(ctx));
             else


### PR DESCRIPTION
This pull request adds `pk;sw m` and `pk;sw e` as aliases to `pk;sw move` and `pk;sw edit` respectively, as per [Suggestion: pk;switch command aliases](https://developing-cuckoo-ca7.notion.site/74576534b6f9446a8ca9aa8c30c4069c?v=fd0532ef8542479aa02c8bc58154e314&p=c4f17d22c5134b5882239aa1495c61b8&pm=s).