### PR TITLE
feat(bot): 'g' shorthand for pk;m <n> group

### DIFF
--- a/PluralKit.Bot/CommandMeta/CommandTree.cs
+++ b/PluralKit.Bot/CommandMeta/CommandTree.cs
@@ -308,7 +308,7 @@ public partial class CommandTree
             await ctx.Execute<MemberAvatar>(MemberAvatar, m => m.WebhookAvatar(ctx, target));
         else if (ctx.Match("banner", "splash", "cover"))
             await ctx.Execute<MemberEdit>(MemberBannerImage, m => m.BannerImage(ctx, target));
-        else if (ctx.Match("group", "groups"))
+        else if (ctx.Match("group", "groups", "g"))
             if (ctx.Match("add", "a"))
                 await ctx.Execute<GroupMember>(MemberGroupAdd,
                     m => m.AddRemoveGroups(ctx, target, Groups.AddRemoveOperation.Add));


### PR DESCRIPTION
This PR adds `g` as a shorthand for member group commands, i.e. `pk;member <name> groups` -> `pk;member <name> g`, as per [Suggestion: G as alias/shorthand for Group in the Middle of commands](https://developing-cuckoo-ca7.notion.site/74576534b6f9446a8ca9aa8c30c4069c?v=fd0532ef8542479aa02c8bc58154e314&p=c8e46d7dc18945358a61d1f866177e45&pm=s)

(I couldn't find anywhere else this was an issue, I'm 99% sure it's just member groups)