### PR TITLE
Several improvements to guide documentation

### DIFF
--- a/docs/content/command-list.md
+++ b/docs/content/command-list.md
@@ -31,6 +31,8 @@ Some arguments indicate the use of specific Discord features. These include:
 :::
 
 # Commands
+*Space is allowed after `pk;`; e.g. `pk;system` and `pk; system` have the same effect.
+
 ## System commands
 *To target a specific system, replace `[system]` with that system's 5-character ID, a Discord account ID, or a @mention - note that system names can not be used here. If no system ID is specified, defaults to targeting your own system. For most commands, adding `-clear` will clear/delete the field.*
 *`pk;s` is shorthand for `pk;system`*
@@ -59,7 +61,7 @@ Some arguments indicate the use of specific Discord features. These include:
 
 ## Member commands
 *Replace `<member>` with a member's name, 5-character ID or display name. For most commands, adding `-clear` will clear/delete the field.*
-*`pk;b` is shorthand for `pk;member`*
+*`pk;m` is shorthand for `pk;member`*
 - `pk;member <member>` - Shows information about a member.
 - `pk;member new <name>` - Creates a new system member.
 - `pk;member <member> rename <new name>` - Changes the name of a member.

--- a/docs/content/command-list.md
+++ b/docs/content/command-list.md
@@ -120,7 +120,7 @@ Some arguments indicate the use of specific Discord features. These include:
 - `pk;switch delete all` - Deletes all logged switches.
 
 ## Autoproxy commands
-*`pk;ap` or `pk;auto` are shorthand for `pk;autproxy`*
+*`pk;ap` or `pk;auto` are shorthand for `pk;autoproxy`*
 - `pk;autoproxy off` - Disables autoproxying for your system in the current server.
 - `pk;autoproxy front` - Sets your system's autoproxy in this server to proxy the first member currently registered as front.
 - `pk;autoproxy latch` - Sets your system's autoproxy in this server to proxy the last manually proxied member.

--- a/docs/content/command-list.md
+++ b/docs/content/command-list.md
@@ -33,6 +33,7 @@ Some arguments indicate the use of specific Discord features. These include:
 # Commands
 ## System commands
 *To target a specific system, replace `[system]` with that system's 5-character ID, a Discord account ID, or a @mention - note that system names can not be used here. If no system ID is specified, defaults to targeting your own system. For most commands, adding `-clear` will clear/delete the field.*
+*`pk;s` is shorthand for `pk;system`*
 - `pk;system [system]` - Shows information about a system.
 - `pk;system new [name]` - Creates a new system registered to your account.
 - `pk;system [system] rename [new name]` - Changes the name of your system.
@@ -58,6 +59,7 @@ Some arguments indicate the use of specific Discord features. These include:
 
 ## Member commands
 *Replace `<member>` with a member's name, 5-character ID or display name. For most commands, adding `-clear` will clear/delete the field.*
+*`pk;b` is shorthand for `pk;member`*
 - `pk;member <member>` - Shows information about a member.
 - `pk;member new <name>` - Creates a new system member.
 - `pk;member <member> rename <new name>` - Changes the name of a member.
@@ -83,6 +85,7 @@ Some arguments indicate the use of specific Discord features. These include:
 
 ## Group commands
 *Replace `<group>` with a group's name, 5-character ID or display name. For most commands, adding `-clear` will clear/delete the field.*
+*`pk;g` is shorthand for `pk;group`*
 - `pk;group <group>` - Shows information about a group.
 - `pk;group new <name>` - Creates a new group.
 - `pk;group list` - Lists all groups in your system.
@@ -100,20 +103,23 @@ Some arguments indicate the use of specific Discord features. These include:
 - `pk;group <group> id` - Prints a group's id. 
 
 ## Switching commands
+*`pk;sw` is shorthand for `pk;switch`*
 - `pk;switch [member...]` - Registers a switch with the given members.
 - `pk;switch out` - Registers a 'switch-out' - a switch with no associated members.
-- `pk;switch edit <member...|out>` - Edits the members in the latest switch. 
+- `pk;switch edit <member...|out>` - Edits the members in the latest switch. Only works within 10 minutes of the edited message.
 - `pk;switch move <time>` - Moves the latest switch backwards in time.
 - `pk;switch delete` - Deletes the latest switch.
 - `pk;switch delete all` - Deletes all logged switches.
 
 ## Autoproxy commands
+*`pk;ap` or `pk;auto` are shorthand for `pk;autproxy`*
 - `pk;autoproxy off` - Disables autoproxying for your system in the current server.
 - `pk;autoproxy front` - Sets your system's autoproxy in this server to proxy the first member currently registered as front.
 - `pk;autoproxy latch` - Sets your system's autoproxy in this server to proxy the last manually proxied member.
 - `pk;autoproxy \<member>` - Sets your system's autoproxy in this server to proxy a specific member.
 
 ## Config commands
+*`pk;cfg` is shorthand for `pk;config`*
 - `pk;config timezone [location]` - Changes the time zone of your system.
 - `pk;config ping <enable|disable>` - Changes your system's ping preferences.
 - `pk;config autoproxy timeout [<duration>|off|reset]` - Sets the latch timeout duration for your system.
@@ -121,7 +127,7 @@ Some arguments indicate the use of specific Discord features. These include:
 - `pk;config proxy case [on|off]` - Toggles case sensitive proxy tags for your system.
 
 ## Server owner commands
-*(all commands here require Manage Server permission)*
+*All commands here require Manage Server permission.*
 - `pk;log channel` - Shows the currently set log channel
 - `pk;log channel <channel>` - Sets the given channel to log all proxied messages.
 - `pk;log channel -clear` - Clears the currently set log channel.
@@ -133,14 +139,14 @@ Some arguments indicate the use of specific Discord features. These include:
 - `pk;blacklist remove <#channel> [#channel...]` - Removes the given channel(s) from the proxy blacklist.
 
 ## Utility
-- `pk;message <message id|message link|reply>` - Looks up information about a proxied message by its message ID or link.
+- `pk;message <message id|message link|reply>` or `pk;msg` - Looks up information about a proxied message by its message ID or link.
 - `pk;invite` - Sends the bot invite link for PluralKit.
 - `pk;import` - Imports a data file from PluralKit or Tupperbox.
 - `pk;export` - Exports a data file containing your system information.
 - `pk;debug permissions [server id]` - [Checks the given server's permission setup](/staff/permissions/#permission-checker-command) to check if it's compatible with PluralKit.
 - `pk;debug proxying <message link|reply>` - Checks why your message has not been proxied.
-- `pk;edit [message link|reply] <new content>` - Edits a proxied message. Without an explicit message target, will target the last message proxied by your system in the current channel. **Does not support message IDs!**
-- `pk;reproxy [message link|reply] <member name|ID>` - Reproxies a message using a different member. Without an explicit message target, will target the last message proxied by your system in the current channel.
+- `pk;edit [message link|reply] <new content>` or `pk;e` - Edits a proxied message. Without an explicit message target, will target the last message proxied by your system in the current channel. **Does not support message IDs!**
+- `pk;reproxy [message link|reply] <member name|ID>` or `pk;rp` - Reproxies a message using a different member. Without an explicit message target, will target the last message proxied by your system in the current channel. Only works on the last message, or within 1 minute of the reproxied message. Doesn't work on a non-proxied message.
 - `pk;link <account>` - Links your system to a different account.
 - `pk;unlink [account]` - Unlinks an account from your system.
 
@@ -151,9 +157,9 @@ Some arguments indicate the use of specific Discord features. These include:
 - `pk;s webhook [url]` - Shows or updates the [dispatch webhook](/api/dispatch) URL for your system.
 
 ## Help
-- `pk;help` - Displays a basic help message describing how to use the bot.
+- `pk;help` or `pk;h` - Displays a basic help message describing how to use the bot.
 - `pk;help proxy` - Directs you to [this page](/guide/#proxying).
 - `pk;system help` - Lists system-related commands.
 - `pk;member help` - Lists member-related commands.
 - `pk;switch help` - Lists switch-related commands.
-- `pk;commands` - Shows inline command documentation, or directs you to this page.
+- `pk;commands` or `pk;c` or `pk;cmd` - Shows inline command documentation, or directs you to this page.

--- a/docs/content/command-list.md
+++ b/docs/content/command-list.md
@@ -35,9 +35,9 @@ Some arguments indicate the use of specific Discord features. These include:
 
 ## Non `pk;` commands
 
-- `\` disable autoproxying for this message only
-- `\\` clear latch status without disabling autoproxy
-- `[tag]` e.g. `S: message` if autoproxy is on, proxy this message, based on configured `member proxy` tags
+- `\` as a one-off exception, don't proxy this message, without changing latch/switch/autoproxy
+- `\\` don't proxy this message, and clear latch status, without disabling autoproxy
+- `[tag]` e.g. `S: message` if `pk;system proxy` is on, proxy this message, based on configured `pk;member proxy` tags
 
 ## System commands
 *To target a specific system, replace `[system]` with that system's 5-character ID, a Discord account ID, or a @mention - note that system names can not be used here. If no system ID is specified, defaults to targeting your own system. For most commands, adding `-clear` will clear/delete the field.*

--- a/docs/content/command-list.md
+++ b/docs/content/command-list.md
@@ -30,7 +30,7 @@ Some arguments indicate the use of specific Discord features. These include:
 ![Upload example](./assets/upload_arg.png)
 :::
 
-# Commands
+# User commands
 *Space is allowed after `pk;`; e.g. `pk;system` and `pk; system` have the same effect.*
 
 ## System commands
@@ -128,18 +128,6 @@ Some arguments indicate the use of specific Discord features. These include:
 - `pk;config autoproxy account [on|off]` - Toggles autoproxy globally for the current account.
 - `pk;config proxy case [on|off]` - Toggles case sensitive proxy tags for your system.
 
-## Server owner commands
-*All commands here require Manage Server permission.*
-- `pk;log channel` - Shows the currently set log channel
-- `pk;log channel <channel>` - Sets the given channel to log all proxied messages.
-- `pk;log channel -clear` - Clears the currently set log channel.
-- `pk;log disable <#channel> [#channel...]` - Disables logging messages posted in the given channel(s) (useful for staff channels and such).
-- `pk;log enable <#channel> [#channel...]` - Re-enables logging messages posted in the given channel(s).
-- `pk;log show` - Displays the current list of channels where logging is disabled.
-- `pk;logclean <on|off>` - Enables or disables [log cleanup](/staff/compatibility/#log-cleanup).
-- `pk;blacklist add <#channel> [#channel...]` - Adds the given channel(s) to the proxy blacklist (proxying will be disabled here)
-- `pk;blacklist remove <#channel> [#channel...]` - Removes the given channel(s) from the proxy blacklist.
-
 ## Utility
 - `pk;message <message id|message link|reply>` or `pk;msg` - Looks up information about a proxied message by its message ID or link.
 - `pk;invite` - Sends the bot invite link for PluralKit.
@@ -152,12 +140,6 @@ Some arguments indicate the use of specific Discord features. These include:
 - `pk;link <account>` - Links your system to a different account.
 - `pk;unlink [account]` - Unlinks an account from your system.
 
-## API
-*(for using the [PluralKit API](/api), useful for developers)*
-- `pk;token` - DMs you a token for using the PluralKit API.
-- `pk;token refresh` - Refreshes your API token and invalidates the old one.
-- `pk;s webhook [url]` - Shows or updates the [dispatch webhook](/api/dispatch) URL for your system.
-
 ## Help
 - `pk;help` or `pk;h` - Displays a basic help message describing how to use the bot.
 - `pk;help proxy` - Directs you to [this page](/guide/#proxying).
@@ -165,3 +147,21 @@ Some arguments indicate the use of specific Discord features. These include:
 - `pk;member help` - Lists member-related commands.
 - `pk;switch help` - Lists switch-related commands.
 - `pk;commands` or `pk;c` or `pk;cmd` - Shows inline command documentation, or directs you to this page.
+
+# Server owner commands
+*All commands here require Manage Server permission.*
+- `pk;log channel` - Shows the currently set log channel
+- `pk;log channel <channel>` - Sets the given channel to log all proxied messages.
+- `pk;log channel -clear` - Clears the currently set log channel.
+- `pk;log disable <#channel> [#channel...]` - Disables logging messages posted in the given channel(s) (useful for staff channels and such).
+- `pk;log enable <#channel> [#channel...]` - Re-enables logging messages posted in the given channel(s).
+- `pk;log show` - Displays the current list of channels where logging is disabled.
+- `pk;logclean <on|off>` - Enables or disables [log cleanup](/staff/compatibility/#log-cleanup).
+- `pk;blacklist add <#channel> [#channel...]` - Adds the given channel(s) to the proxy blacklist (proxying will be disabled here)
+- `pk;blacklist remove <#channel> [#channel...]` - Removes the given channel(s) from the proxy blacklist.
+
+# API commands
+*(for using the [PluralKit API](/api), useful for developers)*
+- `pk;token` - DMs you a token for using the PluralKit API.
+- `pk;token refresh` - Refreshes your API token and invalidates the old one.
+- `pk;s webhook [url]` - Shows or updates the [dispatch webhook](/api/dispatch) URL for your system.

--- a/docs/content/command-list.md
+++ b/docs/content/command-list.md
@@ -35,9 +35,9 @@ Some arguments indicate the use of specific Discord features. These include:
 
 ## Non `pk;` commands
 
-- `\` as a one-off exception, don't proxy this message, without changing latch/switch/autoproxy
-- `\\` don't proxy this message, and clear latch status, without disabling autoproxy
-- `[tag]` e.g. `S: message` if `pk;system proxy` is on, proxy this message, based on configured `pk;member proxy` tags
+- `\` - as a one-off exception, don't proxy this message, without changing latch/switch/autoproxy
+- `\\` - don't proxy this message, and clear latch status, without disabling autoproxy
+- `[tag]` e.g. `S: message` - if `pk;system proxy` is on, proxy this message, based on configured `pk;member proxy` tags
 
 ## System commands
 *To target a specific system, replace `[system]` with that system's 5-character ID, a Discord account ID, or a @mention - note that system names can not be used here. If no system ID is specified, defaults to targeting your own system. For most commands, adding `-clear` will clear/delete the field.*

--- a/docs/content/command-list.md
+++ b/docs/content/command-list.md
@@ -31,7 +31,7 @@ Some arguments indicate the use of specific Discord features. These include:
 :::
 
 # Commands
-*Space is allowed after `pk;`; e.g. `pk;system` and `pk; system` have the same effect.
+*Space is allowed after `pk;`; e.g. `pk;system` and `pk; system` have the same effect.*
 
 ## System commands
 *To target a specific system, replace `[system]` with that system's 5-character ID, a Discord account ID, or a @mention - note that system names can not be used here. If no system ID is specified, defaults to targeting your own system. For most commands, adding `-clear` will clear/delete the field.*

--- a/docs/content/command-list.md
+++ b/docs/content/command-list.md
@@ -33,6 +33,12 @@ Some arguments indicate the use of specific Discord features. These include:
 # User commands
 *Space is allowed after `pk;`; e.g. `pk;system` and `pk; system` have the same effect.*
 
+## Non `pk;` commands
+
+- `\` disable autoproxying for this message only
+- `\\` clear latch status without disabling autoproxy
+- `[tag]` e.g. `S: message` if autoproxy is on, proxy this message, based on configured `member proxy` tags
+
 ## System commands
 *To target a specific system, replace `[system]` with that system's 5-character ID, a Discord account ID, or a @mention - note that system names can not be used here. If no system ID is specified, defaults to targeting your own system. For most commands, adding `-clear` will clear/delete the field.*
 *`pk;s` is shorthand for `pk;system`*

--- a/docs/content/command-list.md
+++ b/docs/content/command-list.md
@@ -130,15 +130,15 @@ Some arguments indicate the use of specific Discord features. These include:
 
 ## Utility
 - `pk;message <message id|message link|reply>` or `pk;msg` - Looks up information about a proxied message by its message ID or link.
+- `pk;edit [message link|reply] <new content>` or `pk;e` - Edits a proxied message. Without an explicit message target, will target the last message proxied by your system in the current channel. **Does not support message IDs!**
+- `pk;reproxy [message link|reply] <member name|ID>` or `pk;rp` - Reproxies a message using a different member. Without an explicit message target, will target the last message proxied by your system in the current channel. Only works on the last message, or within 1 minute of the reproxied message. Doesn't work on a non-proxied message.
+- `pk;link <account>` - Links your system to a different account.
+- `pk;unlink [account]` - Unlinks an account from your system.
 - `pk;invite` - Sends the bot invite link for PluralKit.
 - `pk;import` - Imports a data file from PluralKit or Tupperbox.
 - `pk;export` - Exports a data file containing your system information.
 - `pk;debug permissions [server id]` - [Checks the given server's permission setup](/staff/permissions/#permission-checker-command) to check if it's compatible with PluralKit.
 - `pk;debug proxying <message link|reply>` - Checks why your message has not been proxied.
-- `pk;edit [message link|reply] <new content>` or `pk;e` - Edits a proxied message. Without an explicit message target, will target the last message proxied by your system in the current channel. **Does not support message IDs!**
-- `pk;reproxy [message link|reply] <member name|ID>` or `pk;rp` - Reproxies a message using a different member. Without an explicit message target, will target the last message proxied by your system in the current channel. Only works on the last message, or within 1 minute of the reproxied message. Doesn't work on a non-proxied message.
-- `pk;link <account>` - Links your system to a different account.
-- `pk;unlink [account]` - Unlinks an account from your system.
 
 ## Help
 - `pk;help` or `pk;h` - Displays a basic help message describing how to use the bot.

--- a/docs/content/command-list.md
+++ b/docs/content/command-list.md
@@ -137,8 +137,8 @@ Some arguments indicate the use of specific Discord features. These include:
 - `pk;invite` - Sends the bot invite link for PluralKit.
 - `pk;import` - Imports a data file from PluralKit or Tupperbox.
 - `pk;export` - Exports a data file containing your system information.
-- `pk;debug permissions [server id]` - [Checks the given server's permission setup](/staff/permissions/#permission-checker-command) to check if it's compatible with PluralKit.
 - `pk;debug proxying <message link|reply>` - Checks why your message has not been proxied.
+- `pk;debug permissions [server id]` - [Checks the given server's permission setup](/staff/permissions/#permission-checker-command) to check if it's compatible with PluralKit.
 
 ## Help
 - `pk;help` or `pk;h` - Displays a basic help message describing how to use the bot.

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -371,7 +371,7 @@ Using the examples so far (ignoring the remove commands), if you run `pk;system 
     [qazws] Joanne (tags [text], J:text)
     [wefje] Skyler (S:text)
     [nxzpa] Unknown (?text?, 🤷text)
-    Sorting by name. 4 results.
+    Sorting by name. 5 results.
 
 and `pk;system list full @Craig#5432` will output something like this:
 

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -449,6 +449,8 @@ to:
 
 *:warning: This only works on your last message, or a message sent within the last 1 minute.*
 
+*:warning: This does not work on a message you sent as your actual user account (i.e. one you didn't proxy).*
+
 #### Deleting messages
 To delete a PluralKit-proxied message, react to it with the `:x:` :x: emoji.
 

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -205,7 +205,7 @@ In such cases you can set the member's *display name*. Which will, well, display
 a display name using the `pk;member displayname` command, like so:
 
     pk;member Joanne displayname Jo
-    pk;m Skyler displayname Sky (they/them)
+    pk;m Skyler displayname Sky (he/him)
 
 To remove a display name, just use the same command with no last parameter, eg:
 

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -738,8 +738,12 @@ To update your system privacy settings, use the following commands:
 
     pk;system privacy <subject> <level>
     
-*  `<subject>` is either `description`, `fronter`, `fronthistory` or `list`, corresponding to the options above
-  *  (or `all` in order to change all subjects at once)
+* `<subject>` is one of:
+  * `description`
+  * `fronter`
+  * `fronthistory`
+  * `list`
+  * `all` (to change all subjects at once)
 * `<level>` is either `public` or `private`
 
 For example:
@@ -772,8 +776,15 @@ To update a member's privacy you can use the command:
     pk;member <member> privacy <subject> <level>
 
 * `<member>` is the name or the id of a member in your system
-* `<subject>` is one of `name`, `description`, `avatar`, `birthday`, `pronouns`, `metadata`, or `visiblity` corresponding to the options above
-  * (or `all` to change all subjects at once)
+* `<subject>` is one of:
+  * `name`
+  * `description`
+  * `avatar`
+  * `birthday`
+  * `pronouns`
+  * `metadata`
+  * `visiblity`
+  * `all` (to change all subjects at once)
 * `<level>` is either `public` or `private`
 
 For example:

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -18,7 +18,7 @@ Use this link to add the bot to your server:
 
 Once you go through the wizard, the bot account will automatically join the server you've chosen. Please ensure the bot has the *Read Messages*, *Send Messages*, *Manage Messages*, *Attach Files* and *Manage Webhooks* permission in the channels you want it to work in. 
 
-*ℹ️ You can have a space after `pk;`; e.g. `pk;system` and `pk; system` will do the same thing.*
+*:information_source: You can have a space after `pk;`; e.g. `pk;system` and `pk; system` will do the same thing.*
 
 ## System management
 In order to do most things with the PluralKit bot, you'll need to have a system registered with it. A *system* is a collection of *system members* that may be used by one or more *Discord accounts*.
@@ -34,7 +34,7 @@ Optionally, you can attach a *system name*, which will be displayed in various i
 
     pk;system new My System Name
 
-*ℹ️ You can also use `pk;s` as shorthand for `pk;system`.*
+*:information_source: You can also use `pk;s` as shorthand for `pk;system`.*
 
 ### Viewing information about a system
 To view information about your own system, simply type:
@@ -141,6 +141,8 @@ In order to do most things related to PluralKit, you need to work with *system m
 
 Most member commands follow the format of `pk;member MemberName verb Parameter`. Note that if a member's name has multiple words, you'll need to enclose it in "double quotes" throughout the commands below (_except_ for `pk;member new`).
 
+*:information_source: For all memer commands, you can use either the member name or display name, but not the proxy tag.*
+
 ### Creating a member
 You can't do much with PluralKit without having registered members with your system, but doing so is quite simple - just use the `pk;member new` command followed by the member's name, like so:
 
@@ -150,13 +152,13 @@ You can't do much with PluralKit without having registered members with your sys
     pk;member new Unknown
     pk;member new Skyler
 
-`@PluralKit` will respond with a confirmation and the member ID code, like so:
+PluralKit will respond with a confirmation and the member ID code, like so:
 
     PluralKit: ✅ Member "John" (qazws) registered! 
 
-*⚠️ As the one exception to the rule above, if the name consists of multiple words you must *not* enclose it in double quotes.*
+*:warning: As the one exception to the rule above, if the name consists of multiple words you must *not* enclose it in double quotes.*
 
-*ℹ️ You can also use `pk;m` as shorthand for `pk;member`.*
+*:information_source: You can also use `pk;m` as shorthand for `pk;member`.*
 
 ### Looking up member info
 To view information about a member, there are a couple ways to do it. Either you can address a member by their name (if they're in your own system), by their 5-character *member ID*, or by their *display name*, like so:
@@ -174,9 +176,9 @@ To list all the members in a system, use the `pk;system list` command. This will
     pk;system @Craig#5432 list
     pk;system qazws list
 
-*ℹ️ You can also use `l` as shorthand for `list`.*
+*:information_source: You can also use `l` as shorthand for `list`.*
 
-If you run `pk;system info @Craig#5432` after the example setup so far, `@PluralKit` will output something like this:
+If you run `pk;system info @Craig#5432` after the example setup so far, PluralKit will output something like this:
 
     My System Name
     | Tag | Linked accounts       | Members (5) |
@@ -233,7 +235,7 @@ To clear a member description, use the command with no additional parameters (e.
 A system member can have an associated color value.
 This color is *not* displayed as a name color on proxied messages due to a Discord limitation,
 but it's shown in member cards, and it can be used in third-party apps, too.
-To set a member color, use the `pk;member color` command with [a hexadecimal color code](https://htmlcolorcodes.com/), like so, using either the member name or display name:
+To set a member color, use the `pk;member color` command with [a hexadecimal color code](https://htmlcolorcodes.com/), like so:
 
     pk;member Jo color #ff0000
     pk;m Skyler color #87ceeb
@@ -315,9 +317,9 @@ For example, if you want square brackets, the proxy example must be `[text]`. If
 
 You can now type a message enclosed in / prefixed by your proxy tags, and it'll be deleted by PluralKit and reposted with the appropriate member name and avatar (if set).
 
-*⚠️ If you use `pk;member proxy` without "add", it will **replace** the proxy tag(s) for that member. `@PluralKit` will respond with a warning about this, and won't do it unless you click the `Replace` button on that message.*
+*:warning: If you use `pk;member proxy` without "add", it will **replace** the proxy tag(s) for that member. PluralKit will respond with a warning about this, and won't do it unless you click the `Replace` button on that message.*
 
-*⚠️ Currently, you can't use `<angle brackets>` as proxy tags, due to a bug where custom server emojis will (wrongly) be interpreted as proxying with that member (see [issue #37](https://github.com/PluralKit/PluralKit/issues/37)).*
+*:warning: Currently, you can't use `<angle brackets>` as proxy tags, due to a bug where custom server emojis will (wrongly) be interpreted as proxying with that member (see [issue #37](https://github.com/PluralKit/PluralKit/issues/37)).*
 
 ### Using multiple distinct proxy tag pairs
 If you'd like to proxy a member in multiple ways (for example, a name or a nickname, uppercase and lowercase variants, etc), you can add multiple tag pairs.
@@ -363,7 +365,7 @@ use a different proxy bot there), you can use the commands:
 
 ## Results so far
 
-Using the examples so far (ignoring the remove commands), if you run `pk;system list @Craig#5432`, `@PluralKit` will now output something like this:
+Using the examples so far (ignoring the remove commands), if you run `pk;system list @Craig#5432`, PluralKit will now output something like this:
 
     Members of My System Name (abcde)
     [eafas] Alice (✨:text, A:text)
@@ -422,7 +424,7 @@ For example:
     Helo, friends!
     pk;e Hello, friends!
 
-*⚠️ This only works if you make the edit within 10 minutes of the original message.*
+*:warning: This only works if you make the edit within 10 minutes of the original message.*
 
 #### Reproxying messages
 If you are using [autoproxy](#autoproxy) and accidentally used the wrong proxy tag or forgot about your latch/switch status, reply to it with the command `pk;reproxy <member name>` (or as shorthand, `pk;rp`).
@@ -442,9 +444,9 @@ to:
 
     Sky (he/him): Hi, this is Sky.
 
-*⚠️ You must use the full member name, *not* their member tag.*
+*:warning: You must use the full member name, *not* their member tag.*
 
-*⚠️ This only works on your last message, or a message sent within the last 1 minute.*
+*:warning: This only works on your last message, or a message sent within the last 1 minute.*
 
 #### Deleting messages
 To delete a PluralKit-proxied message, react to it with the `:x:` :x: emoji.
@@ -475,7 +477,7 @@ To disable autoproxying for the current server, use the command:
 
     pk;autoproxy off
 
-*ℹ️ You can also use `pk;ap` or `pk;auto` as shorthand for `pk;autoproxy`.*
+*:information_source: You can also use `pk;ap` or `pk;auto` as shorthand for `pk;autoproxy`.*
 
 ::: tip
 To disable autoproxy for a single message, add a backslash (`\`) to the beginning of your message.
@@ -595,7 +597,7 @@ To log a switch, use the `pk;switch` command with one or more members. For examp
 Note that the order of members are preserved (this is useful for indicating who's "more" at front, if applicable).
 If you want to specify a member with multiple words in their name, remember to encase the name in "double quotes".
 
-*ℹ️ You can also use `pk;sw` as shorthand for `pk;switch`.*
+*:information_source: You can also use `pk;sw` as shorthand for `pk;switch`.*
 
 ### Switching out
 If you want to log a switch with *no* members, you can log a switch-out as follows:
@@ -673,7 +675,7 @@ To create a new group, use the `pk;group new` command:
     
 This will create a new group. Groups all have a 5-letter ID, similar to systems and members.
 
-*ℹ️ You can also use `pk;g` as shorthand for `pk;group`.*
+*:information_source: You can also use `pk;g` as shorthand for `pk;group`.*
 
 ### Adding and removing members to groups
 To add a member to a group, use the `pk;group <group> add` command, eg:

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -18,10 +18,12 @@ Use this link to add the bot to your server:
 
 Once you go through the wizard, the bot account will automatically join the server you've chosen. Please ensure the bot has the *Read Messages*, *Send Messages*, *Manage Messages*, *Attach Files* and *Manage Webhooks* permission in the channels you want it to work in. 
 
+*ℹ️ You can have a space after `pk;`; e.g. `pk;system` and `pk; system` will do the same thing.*
+
 ## System management
 In order to do most things with the PluralKit bot, you'll need to have a system registered with it. A *system* is a collection of *system members* that may be used by one or more *Discord accounts*.
 
-These examples are for the user `@Craig#5432`, who has headmates Alice, Craig Johnson (formerly Craig Smith), Joanne (formerly John, aka Jo), Skyler, and Unknown.
+These examples are for the user `@Craig#5432`, who has headmates Alice, Craig Johnson (formerly Craig Smith), Joanne (formerly John, aka Jo), Skyler (aka Sky), and Unknown.
 
 ### Creating a system
 If you do not already have a system registered, use the following command to create one:
@@ -31,7 +33,9 @@ If you do not already have a system registered, use the following command to cre
 Optionally, you can attach a *system name*, which will be displayed in various information cards, like so:
 
     pk;system new My System Name
-    
+
+*ℹ️ You can also use `pk;s` as shorthand for `pk;system`.*
+
 ### Viewing information about a system
 To view information about your own system, simply type:
 
@@ -40,8 +44,8 @@ To view information about your own system, simply type:
 To view information about *a different* system, there are a number of ways to do so. You can either look up a system by @mention, by account ID, or by system ID. For example:
 
     pk;system @Craig#5432
-    pk;system 466378653216014359
-    pk;system abcde
+    pk;s 466378653216014359
+    pk;s abcde
     
 ### System description
 If you'd like to add a small blurb to your system information card, you can add a *system description*. To do so, use the `pk;system description` command, as follows:
@@ -55,7 +59,7 @@ If you'd like to remove your system description, just type `pk;system descriptio
 ### System avatars
 If you'd like your system to have an associated "system avatar", displayed on your system information card, you can add a system avatar. To do so, use the `pk;system avatar` command. You can either supply it with an direct URL to an image, or attach an image directly. For example.
 
-    pk;system avatar http://placebeard.it/512.jpg
+    pk;s avatar http://placebeard.it/512.jpg
     pk;system avatar [with attached image]
     
 To clear your avatar, simply type `pk;system avatar` with no attachment or link.
@@ -67,8 +71,8 @@ will be `James | The Boys`. This is useful for identifying your system in-chat, 
 a system tag. Note that emojis *are* supported! To set one, use the `pk;system tag` command, like so:
 
     pk;system tag | The Boys
-    pk;system tag (Test System)
-    pk;system tag 🛰️
+    pk;s tag (Test System)
+    pk;s tag 🛰️
 
 If you want to remove your system tag, just type `pk;system tag` with no extra parameters.
 
@@ -116,7 +120,7 @@ If you'd like, you can set a *system time zone*, and as such every date and time
     pk;config timezone America/New_York
     pk;config timezone DE
     pk;config timezone 🇬🇧
-    
+
 You can specify time zones in various ways. In regions with large amounts of time zones (eg. the Americas, Europe, etc),
 specifying an exact time zone code is the best way. To get your local time zone code, visit [this site](https://xske.github.io/tz).
 You can see the full list [here, on Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) (see the column *TZ database name*).
@@ -150,14 +154,16 @@ You can't do much with PluralKit without having registered members with your sys
 
     PluralKit: ✅ Member "John" (qazws) registered! 
 
-⚠️ As the one exception to the rule above, if the name consists of multiple words you must *not* enclose it in double quotes.
+*⚠️ As the one exception to the rule above, if the name consists of multiple words you must *not* enclose it in double quotes.*
+
+*ℹ️ You can also use `pk;m` as shorthand for `pk;member`.*
 
 ### Looking up member info
 To view information about a member, there are a couple ways to do it. Either you can address a member by their name (if they're in your own system), by their 5-character *member ID*, or by their *display name*, like so:
 
     pk;member John
-    pk;member qazws
-    pk;member J
+    pk;m qazws
+    pk;m J
 
 Member IDs are the only way to address a member in another system, and you can find it in various places - for example the system's member list, or on a message info card gotten by reacting to messages with a question mark.
 
@@ -167,6 +173,8 @@ To list all the members in a system, use the `pk;system list` command. This will
     pk;system list
     pk;system @Craig#5432 list
     pk;system qazws list
+
+*ℹ️ You can also use `l` as shorthand for `list`.*
 
 If you run `pk;system info @Craig#5432` after the example setup so far, `@PluralKit` will output something like this:
 
@@ -179,14 +187,14 @@ If you run `pk;system info @Craig#5432` after the example setup so far, `@Plural
 If you want a more detailed list, with fields such as pronouns and description, add the word `full` to the end of the command, like so:
 
     pk;system list full
-    pk;system @Craig#5432 list full
-    pk;system qazws list full
+    pk;s @Craig#5432 l full
+    pk;s qazws l full
 
 ### Member renaming
 If you want to change the name of a member, you can use the `pk;member rename` command, like so:
 
     pk;member John rename Joanne
-    pk;member "Craig Smith" rename "Craig Johnson"
+    pk;m "Craig Smith" rename "Craig Johnson"
 
 ### Member display names
 Normally, when proxying a member, the name displayed in the proxied message will be the member's name. However, in some cases
@@ -197,7 +205,7 @@ In such cases you can set the member's *display name*. Which will, well, display
 a display name using the `pk;member displayname` command, like so:
 
     pk;member Joanne displayname Jo
-    pk;member Skyler displayname Sky (they/them)
+    pk;m Skyler displayname Sky (they/them)
 
 To remove a display name, just use the same command with no last parameter, eg:
 
@@ -228,7 +236,7 @@ but it's shown in member cards, and it can be used in third-party apps, too.
 To set a member color, use the `pk;member color` command with [a hexadecimal color code](https://htmlcolorcodes.com/), like so, using either the member name or display name:
 
     pk;member Jo color #ff0000
-    pk;member Skyler color #87ceeb
+    pk;m Skyler color #87ceeb
 
 To clear a member color, use the command with no color code argument (eg. `pk;member Joanne color`).
 
@@ -236,7 +244,7 @@ To clear a member color, use the command with no color code argument (eg. `pk;me
 If you want your member to have an associated avatar to display on the member information card and on proxied messages, you can set the member avatar. To do so, use the `pk;member avatar` command. You can either supply it with an direct URL to an image, or attach an image directly. For example.
 
     pk;member Jo avatar http://placebeard.it/512.jpg
-    pk;member "Craig Johnson" avatar   (with an attached image)
+    pk;m "Craig Johnson" avatar   (with an attached image)
     
 To preview the current avatar (if one is set), use the command with no arguments:
 
@@ -248,23 +256,23 @@ To clear your avatar, use the subcommand `avatar clear` (eg. `pk;member Joanne a
 If you want your member to have a different avatar for proxies messages than the one displayed on the member card, you can set a proxy avatar. To do so, use the `pk;member proxyavatar` command, in the same way as the normal avatar command above:
 
     pk;member Joanne avatar
-    pk;member Joanne proxyavatar http://placebeard.it/512.jpg
-    pk;member "Craig Johnson" proxyavatar    (with an attached image)
+    pk;m Joanne proxyavatar http://placebeard.it/512.jpg
+    pk;m "Craig Johnson" proxyavatar    (with an attached image)
 
 #### Member server avatar
 You can also set an avatar for a specific server. This will "override" the normal avatar, and will be used when proxying messages and looking up member cards in that server. To do so, use the `pk;member serveravatar` command, in the same way as the normal avatar command above:
 
     pk;member Joanne serveravatar
-    pk;member Joanne serveravatar http://placebeard.it/512.jpg
-    pk;member "Craig Johnson" serveravatar   (with an attached image)
-    pk;member Joanne serveravatar clear
+    pk;m Joanne serveravatar http://placebeard.it/512.jpg
+    pk;m "Craig Johnson" serveravatar   (with an attached image)
+    pk;m Joanne serveravatar clear
 
 ### Member pronouns
 If you want to list a member's preferred pronouns, you can use the pronouns field on a member profile. This is a free text field, so you can put whatever you'd like in there (with a 100 character limit), like so:
 
     pk;member Joanne pronouns she/them
-    pk;member "Craig Johnson" pronouns anything goes, really
-    pk;member Skyler pronouns xe/xir or they/them
+    pk;m "Craig Johnson" pronouns anything goes, really
+    pk;m Skyler pronouns xe/xir, he/him, or they/them
 
 To remove a member's pronouns, use the command with no pronoun argument (eg. `pk;member Jo pronouns`).
 
@@ -272,12 +280,12 @@ To remove a member's pronouns, use the command with no pronoun argument (eg. `pk
 If you want to list a member's birthdate on their information card, you can set their birthdate through PluralKit using the `pk;member birthdate` command. Please use [ISO-8601 format](https://xkcd.com/1179/) (`YYYY-MM-DD`) for best results, like so:
 
     pk;member Jo birthdate 1996-07-24
-    pk;member "Craig Johnson" birthdate 2004-02-28
+    pk;m "Craig Johnson" birthdate 2004-02-28
 
 You can also set a birthdate without a year, either in `MM-DD` format or `Month Day` format, like so:
 
     pk;member Joanne birthdate 07-24
-    pk;member "Craig Johnson" birthdate Feb 28
+    pk;m "Craig Johnson" birthdate Feb 28
     
 To clear a birthdate, use the command with no birthday argument (eg. `pk;member Joanne birthdate`).
 
@@ -301,13 +309,15 @@ To set a proxy tag, use the `pk;member proxy` command on the member in question.
 For example, if you want square brackets, the proxy example must be `[text]`. If you want a letter or emoji prefix, make it something like `A:text` or `🏳️‍🌈:text`. For example:
 
     pk;member Alice proxy ✨:text
-    pk;member "Craig Johnson" proxy {text}
-    pk;member Jo proxy [text]
-    pk;member Skyler proxy S:text
+    pk;m "Craig Johnson" proxy {text}
+    pk;m Jo proxy [text]
+    pk;m Skyler proxy S:text
 
 You can now type a message enclosed in / prefixed by your proxy tags, and it'll be deleted by PluralKit and reposted with the appropriate member name and avatar (if set).
 
-⚠️ Currently, you can't use `<angle brackets>` as proxy tags, due to a bug where custom server emojis will (wrongly) be interpreted as proxying with that member (see [issue #37](https://github.com/PluralKit/PluralKit/issues/37)).
+*⚠️ If you use `pk;member proxy` withoug "add", it will **replace** the proxy tag(s) for that member. `@PluralKit` will respond with a warning about this, and won't do it unless you click the `Replace` button on that message.*
+
+*⚠️ Currently, you can't use `<angle brackets>` as proxy tags, due to a bug where custom server emojis will (wrongly) be interpreted as proxying with that member (see [issue #37](https://github.com/PluralKit/PluralKit/issues/37)).*
 
 ### Using multiple distinct proxy tag pairs
 If you'd like to proxy a member in multiple ways (for example, a name or a nickname, uppercase and lowercase variants, etc), you can add multiple tag pairs.
@@ -316,10 +326,10 @@ When proxying, you may then use any of the tags to proxy for that specific membe
 To add a proxy tag to a member, use the `pk;member proxy add` command:
 
     pk;member Alice proxy add A:text
-    pk;member Joanne proxy add J:text
-    pk;member Craig proxy add C:text
-    pk;member Unknown proxy add ?text?
-    pk;member Unknown proxy add 🤷text
+    pk;m Joanne proxy add J:text
+    pk;m Craig proxy add C:text
+    pk;m Unknown proxy add ?text?
+    pk;m Unknown proxy add 🤷text
 
 To make proxy tags case-insensitive, use:
 
@@ -330,7 +340,7 @@ To make proxy tags case-insensitive, use:
 To remove a proxy tag from a member, use the `pk;member proxy remove` command:
 
     pk;member Joanne proxy remove [text]
-    pk;member "Craig Johnson" proxy remove C:text
+    pk;m "Craig Johnson" proxy remove C:text
 
 ### Keeping your proxy tags
 If you'd like your proxied messages to include the proxy tags, you can enable the "keep proxy tags" option for a given member, like so:
@@ -343,6 +353,13 @@ a member with multiple proxy tags, the proxy tag used to trigger a given proxy w
 The practical effect of this is:
 * **Keep proxy tags on:** `[Message goes here]` -> [Message goes here]
 * **Keep proxy tags off:** `[Message goes here]` -> Message goes here 
+
+### Disabling proxying on a per-server basis
+If you need to disable or re-enable proxying messages for your system entirely in a specific server (for example, if you'd like to
+use a different proxy bot there), you can use the commands:
+    
+    pk;system proxy off
+    pk;s proxy on
 
 ## Results so far
 
@@ -380,7 +397,7 @@ and `pk;system list full @Craig#5432` will output something like this:
     Skyler
     ID: wefje
     Display name: Sky (he/him)
-    Pronouns xe/xir or they/them
+    Pronouns xe/xir, he/him, or they/them
     Proxy tags: S:text
 
     Unknown
@@ -392,25 +409,61 @@ and `pk;system list full @Craig#5432` will output something like this:
 
 ## Interacting with proxied messages
 
-### Querying message information
+### Your own messages
+Since the messages will be posted by PluralKit's webhook, there's no way to edit, delete, or change the message as you would a normal user message. However, PluralKit has commands for that.
+
+#### Editing messages
+To edit a PluralKit-proxied message, reply to it with the command `pk;edit` (or as shorthand, `pk;e`) with the replacement text.
+
+If you want to edit your last message, you can leave out the reply.
+
+For example:
+
+    Helo, friends!
+    pk;e Hello, friends!
+
+*⚠️ This only works if you make the edit within 10 minutes of the original message.*
+
+#### Reproxying messages
+If you are using [autoproxy](#autoproxy) and accidentally used the wrong proxy tag or forgot about your latch/switch status, reply to it with the command `pk;reproxy <member name>` (or as shorthand, `pk;rp`).
+
+If you want to reproxy your last message, you can leave out the reply.
+
+For example:
+
+    a: Hi, this is Sky.
+    pk;rp Skyler
+
+will change the first message from:
+
+    Alice: Hi, this is Sky.
+
+to:
+
+    Sky (he/him): Hi, this is Sky.
+
+*⚠️ You must use the full member name, *not* their member tag.*
+
+*⚠️ This only works on your last message, or a message sent within the last 1 minute.*
+
+#### Deleting messages
+To delete a PluralKit-proxied message, you can react to it with the `:x:` :x: emoji. Note that this only works if the message has
+been sent from your own account.
+
+### Anyone's messages
+
+#### Querying message information
 If you want information about a proxied message (eg. for moderation reasons), you can query the message for its sender account, system, member, etc.
 
-Either you can react to the message itself with the :grey_question: or :question: emoji, which will DM you information about the message in question, 
-or you can use the `pk;message` command followed by [the message's ID](https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID-).
+You can
+* react to the message itself with the `:grey_question:` :grey_question: or `:question:` :question: emoji, which will DM you information about the message in question,
+* reply to the mssage with `pk;message` (or as shorthand, `pk;msg`), or
+* use the `pk;message` command followed by [the message's ID](https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID-).
 
-### Pinging a specific user
+#### Pinging the user who sent it
 If you'd like to "ping" the account behind a proxied message without having to query the message and ping them yourself,
-you can react to the message with the :bell: or :exclamation: emoji (or even :ping_pong:), and PluralKit will ping the relevant member and account in the same
+you can react to the message with the `:bell:` :bell: or `:exclamation:` :exclamation: emoji (or even `:ping_pong:` :ping_pong:), and PluralKit will ping the relevant member and account in the same
 channel on your behalf with a link to the message you reacted to.
-
-### Disabling proxying on a per-server basis
-If you need to disable proxying messages for your system entirely in a specific server (for example, if you'd like to
-use a different proxy bot there), you can type `pk;system proxy on/off` to do that.
-
-### Deleting messages
-Since the messages will be posted by PluralKit's webhook, there's no way to delete the message as you would a normal user message.
-To delete a PluralKit-proxied message, you can react to it with the :x: emoji. Note that this only works if the message has
-been sent from your own account.
 
 ## Autoproxy
 The bot's *autoproxy* feature allows you to have messages be proxied without directly including the proxy tags. Autoproxy can be set up in various ways. There are three autoproxy modes currently implemented:
@@ -422,18 +475,19 @@ To see your system's current autoproxy settings, simply use the command:
 To disable autoproxying for the current server, use the command:
 
     pk;autoproxy off
-    
-*(hint: `pk;autoproxy` can be shortened to `pk;ap` in all related commands)*
+
+*ℹ️ You can also use `pk;ap` or `pk;auto` as shorthand for `pk;autoproxy`.*
 
 ::: tip
 To disable autoproxy for a single message, add a backslash (`\`) to the beginning of your message.
+To clear which member is currently latch, add a double backslash (`\\`) to the beginning of your message.
 :::
 
 #### Front mode
 This autoproxy mode will proxy messages as the current *first* fronter of the system. If you register a switch with `Alice` and `Skyler`, messages without proxy tags will be autoproxied as `Alice`.
 To enable front-mode autoproxying for a given server, use the following command:
 
-    pk;autoproxy front
+    pk;ap front
     
 #### Latch mode
 This autoproxy mode will essentially "continue" previous proxy tags. If you proxy a message with `Alice`'s proxy tags, messages posted afterwards will be proxied as Alice. Proxying again with someone else's proxy tags, say, `Skyler`, will cause messages *from then on* to be proxied as Skyler.
@@ -441,7 +495,7 @@ In other words, it means proxy tags become "sticky". This will carry over across
 
 To enable latch-mode autoproxying for a given server, use the following command:
 
-    pk;autoproxy latch
+    pk;ap latch
 
 To set the latched member, use their proxy tags. To disable autoproxy for a single message, start a message with one backslash (`\`). To clear the current latched member, start a message with two backslashes (`\\`).
 
@@ -459,11 +513,11 @@ By default, latch mode times out after 6 hours. It is possible to change this:
 
 To reset the duration, use the following command:
 
-    pk;autoproxy timeout reset
+    pk;ap timeout reset
 
 To disable timeout (never timeout), use the following command:
 
-    pk;autoproxy timeout disable
+    pk;ap timeout disable
 
 ### Disabling front/latch autoproxy on a per-member basis
 If a system uses front or latch mode autoproxy, but one member prefers to send messages through the account (and not proxy), you can disable the front and latch modes for that specific member.
@@ -472,7 +526,7 @@ If a system uses front or latch mode autoproxy, but one member prefers to send m
 
 To re-enable front / latch modes for that member, use the following command:
 
-    pk;member <name> autoproxy on
+    pk;m <name> autoproxy on
 
 This will *not* disable member mode autoproxy. If you do not wish to autoproxy, please turn off autoproxy instead of setting autoproxy to a specific member.
 
@@ -486,7 +540,7 @@ To disable autoproxy for the current account, use the following command:
 
 To re-enable autoproxy for the current account, use the following command:
 
-    pk;autoproxy account enable
+    pk;ap account enable
 
 ::: tip
 This subcommand can also be run in DMs.
@@ -496,7 +550,7 @@ This subcommand can also be run in DMs.
 
 For example, using [the setup example above](#setting-up-proxy-tags), `@Craig#5432` can type this:
 
-    pk;autoproxy latch
+    pk;ap latch
     I haven't used a tag yet, so this message comes from @Craig#5432
     ✨: hello, this is Alice via autoproxy (using an explicit prefix tag)
     this is still Alice (using latch without tag)
@@ -504,7 +558,7 @@ For example, using [the setup example above](#setting-up-proxy-tags), `@Craig#54
     but I'm still latched! (this also is sent from Alice via autoproxy)
     [hello, this is Joanne, using autoproxy and a surround tag]
     still Jo on latch!
-    J: I could use my prefix or surround tags if I want, but don't have to
+    j: I could use my prefix or surround tags if I want, but don't have to
     because the last time I used a tag, I used mine (Jo's)
     \\now I'm clearing latch; this is from @Craig#5432
     and now new messages will be from @Craig#5432 because latch is cleared
@@ -513,16 +567,16 @@ For example, using [the setup example above](#setting-up-proxy-tags), `@Craig#54
 
 and the result will look like this:
 
-    @Craig#5432: pk;autoproxy latch
+    @Craig#5432: pk;ap latch
     @Craig#5432: I haven't used a tag yet, so this message comes from @Craig#5432
     Alice: hello, this is Alice via autoproxy (using an explicit prefix tag)
     Alice: this is still Alice (using latch without tag)
     @Craig#5432: I'm sending this message one-off as @Craig#5432, without proxy
     Alice: but I'm still latched! (this also is sent from Alice via autoproxy)
-    Jo: hello, this is Joanne, using autoproxy and a surround tag
-    Jo: still Jo on latch!
-    Jo: I could use my prefix or surround tags if I want, but don't have to
-    Jo: because the last time I used a tag, I used mine (Jo's)
+    AdminJo: hello, this is Joanne, using autoproxy and a surround tag
+    AdminJo: still Jo on latch!
+    AdminJo: I could use my prefix or surround tags if I want, but don't have to
+    AdminJo: because the last time I used a tag, I used mine (Jo's)
     @Craig#5432: now I'm clearing latch; this is from @Craig#5432
     @Craig#5432: and now new messages will be from @Craig#5432 because latch is cleared
     Unknown: but autoproxy is still on
@@ -542,10 +596,12 @@ To log a switch, use the `pk;switch` command with one or more members. For examp
 Note that the order of members are preserved (this is useful for indicating who's "more" at front, if applicable).
 If you want to specify a member with multiple words in their name, remember to encase the name in "double quotes".
 
+*ℹ️ You can also use `pk;sw` as shorthand for `pk;switch`.*
+
 ### Switching out
 If you want to log a switch with *no* members, you can log a switch-out as follows:
 
-    pk;switch out
+    pk;sw out
 
 ### Moving switches
 If you want to log a switch that happened further back in time, you can log a switch and then *move* it back in time, using the `pk;switch move` command.
@@ -553,9 +609,9 @@ You can either specify a time either in relative terms (X days/hours/minutes/sec
 Absolute times will be interpreted in the [system time zone](#setting-a-system-time-zone). For example:
 
     pk;switch move 1h
-    pk;switch move 4d12h
-    pk;switch move 2 PM
-    pk;switch move May 8, 4:30 PM
+    pk;sw move 4d12h
+    pk;sw move 2 PM
+    pk;sw move May 8, 4:30 PM
 
 Note that you can't move a switch *before* the *previous switch*, to avoid breaking consistency. Here's a rough ASCII-art illustration of this:
 
@@ -578,22 +634,22 @@ If you'd like to clear your system's entire switch history, use the `pk;switch d
 To see the current fronter in a system, use the `pk;system fronter` command. You can use this on your current system, or on other systems. For example:
 
     pk;system fronter
-    pk;system @Craig#5432 fronter
-    pk;system qazws fronter
+    pk;s @Craig#5432 fronter
+    pk;s qazws fronter
 
 ### Querying front history
 To look at the front history of a system (currently limited to the last 10 switches). use the `pk;system fronthistory` command, for example:
 
     pk;system fronthistory
-    pk;system @Craig#5432 fronthistory
-    pk;system qazws fronthistory
+    pk;s @Craig#5432 fronthistory
+    pk;s qazws fronthistory
     
 ### Querying front percentage
 To look at the per-member breakdown of the front over a given time period, use the `pk;system frontpercent` command. If you don't provide a time period, it'll default to 30 days. For example:
 
     pk;system frontpercent
-    pk;system @Craig#5432 frontpercent 7d
-    pk;system qazws frontpercent 100d12h
+    pk;s @Craig#5432 frontpercent 7d
+    pk;s qazws frontpercent 100d12h
 
 Note that in cases of switches with multiple members, each involved member will have the full length of the switch counted towards it. This means that the percentages may add up to over 100%.
 <br> It is possible to disable this with the `-flat` flag; percentages will then add up to 100%.
@@ -618,6 +674,8 @@ To create a new group, use the `pk;group new` command:
     
 This will create a new group. Groups all have a 5-letter ID, similar to systems and members.
 
+*ℹ️ You can also use `pk;g` as shorthand for `pk;group`.*
+
 ### Adding and removing members to groups
 To add a member to a group, use the `pk;group <group> add` command, eg:
 
@@ -625,18 +683,18 @@ To add a member to a group, use the `pk;group <group> add` command, eg:
     
 You can add multiple members to a group by separating them with spaces, eg:
 
-    pk;group MyGroup add Joanne Skyler Alice
+    pk;g MyGroup add Joanne Skyler Alice
 
 Similarly, you can remove members from a group, eg:
 
-    pk;group MyGroup remove Skyler
+    pk;g MyGroup remove Skyler
     
 ### Listing members in a group
 To list all the members in a group, use the `pk;group <group> list` command.
 The syntax works the same as `pk;system list`, and also allows searching and sorting, eg:
 
     pk;group MyGroup list
-    pk;group MyGroup list --by-message-count jo
+    pk;g MyGroup list --by-message-count jo
     
 ### Listing all your groups
 In the same vein, you can list all the groups in your system with the `pk;group list` command:
@@ -652,15 +710,15 @@ Groups can be renamed:
 
 Groups can have icons that show in on the group card:
     
-    pk;group MyGroup icon https://my.link.to/image.png
+    pk;g MyGroup icon https://my.link.to/image.png
     
 Groups can have descriptions:
 
-    pk;group MyGroup description This is my cool group description! :)
+    pk;g MyGroup description This is my cool group description! :)
     
 Groups can be deleted:
 
-    pk;group MyGroup delete
+    pk;g MyGroup delete
 
 ## Privacy
 There are various reasons you may not want information about your system or your members to be public. As such, there are a few controls to manage which information is publicly accessible or not.
@@ -684,8 +742,8 @@ where `<subject>` is either `description`, `fronter`, `fronthistory` or `list`, 
 For example:
 
     pk;system privacy description private
-    pk;system privacy fronthistory public
-    pk;system privacy list private
+    pk;s privacy fronthistory public
+    pk;s privacy list private
 
 When the **member list** is **private**, other users will not be able to view the full member list of your system, but they can still query individual members given their 5-letter ID. If **current fronter** is private, but **front history** isn't, someone can still see the current fronter by looking at the history (this combination doesn't make much sense).
 
@@ -706,9 +764,9 @@ However, there are two catches:
 - When the **name** is set to private, it will be replaced by the member's **display name**, but only if they have one! If the member has no display name, **name privacy will not do anything**. PluralKit still needs some way to refer to a member by name :) 
 - When **visibility** is set to private, the member will not show up in member lists unless `-all` is used in the command (and you are part of the system).
 
-To update a members privacy you can use the command:
+To update a member's privacy you can use the command:
 
-    member <member> privacy <subject> <level>
+    pk;member <member> privacy <subject> <level>
 
 where `<member>` is the name or the id of a member in your system, `<subject>` is either `name`, `description`, `avatar`, `birthday`, `pronouns`, `metadata`, or `visiblity` corresponding to the options above, and `<level>` is either `public` or `private`. `<subject>` can also be `all` in order to change all subjects at once.  
 `metadata` will affect the message count, the date created, the last fronted, and the last message information.
@@ -716,9 +774,9 @@ where `<member>` is the name or the id of a member in your system, `<subject>` i
 For example:
 
     pk;member Joanne privacy visibility private
-    pk;member "Craig Johnson" privacy description public
-    pk;member Alice privacy birthday public
-    pk;member Skyler privacy all private
+    pk;m "Craig Johnson" privacy description public
+    pk;m Alice privacy birthday public
+    pk;m Skyler privacy all private
 
 ## Importing and exporting data
 If you're a user of another proxy bot (eg. Tupperbox), or you want to import a saved system backup, you can use the importing and exporting commands.

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -415,7 +415,7 @@ Since the messages will be posted by PluralKit's webhook, there's no way to edit
 #### Editing messages
 To edit a PluralKit-proxied message, reply to it with the command `pk;edit` (or as shorthand, `pk;e`) with the replacement text.
 
-If you want to edit your last message, you can leave out the reply.
+If you want to edit your last message in this channel, you can leave out the reply.
 
 For example:
 
@@ -427,7 +427,7 @@ For example:
 #### Reproxying messages
 If you are using [autoproxy](#autoproxy) and accidentally used the wrong proxy tag or forgot about your latch/switch status, reply to it with the command `pk;reproxy <member name>` (or as shorthand, `pk;rp`).
 
-If you want to reproxy your last message, you can leave out the reply.
+If you want to reproxy your last message in this channel, you can leave out the reply.
 
 For example:
 
@@ -447,8 +447,7 @@ to:
 *⚠️ This only works on your last message, or a message sent within the last 1 minute.*
 
 #### Deleting messages
-To delete a PluralKit-proxied message, you can react to it with the `:x:` :x: emoji. Note that this only works if the message has
-been sent from your own account.
+To delete a PluralKit-proxied message, react to it with the `:x:` :x: emoji.
 
 ### Anyone's messages
 

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -556,7 +556,7 @@ For example, using [the setup example above](#setting-up-proxy-tags), `@Craig#54
     this is still Alice (using latch without tag)
     \I'm sending this message one-off as @Craig#5432, without proxy
     but I'm still latched! (this also is sent from Alice via autoproxy)
-    [hello, this is Joanne, using autoproxy and a surround tag]
+    [hello, this is Joanne, using autoproxy and a surround tag; notice that I have `keepproxy on`]
     still Jo on latch!
     j: I could use my prefix or surround tags if I want, but don't have to
     because the last time I used a tag, I used mine (Jo's)
@@ -573,9 +573,9 @@ and the result will look like this:
     Alice: this is still Alice (using latch without tag)
     @Craig#5432: I'm sending this message one-off as @Craig#5432, without proxy
     Alice: but I'm still latched! (this also is sent from Alice via autoproxy)
-    AdminJo: hello, this is Joanne, using autoproxy and a surround tag
+    AdminJo: [hello, this is Joanne, using autoproxy and a surround tag; notice that I have `keepproxy on`]
     AdminJo: still Jo on latch!
-    AdminJo: I could use my prefix or surround tags if I want, but don't have to
+    AdminJo: j: I could use my prefix or surround tags if I want, but don't have to
     AdminJo: because the last time I used a tag, I used mine (Jo's)
     @Craig#5432: now I'm clearing latch; this is from @Craig#5432
     @Craig#5432: and now new messages will be from @Craig#5432 because latch is cleared

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -142,6 +142,7 @@ You can't do much with PluralKit without having registered members with your sys
 
     pk;member new John
     pk;member new Craig Smith
+    pk;member new Alice
     
 As the one exception to the rule above, if the name consists of multiple words you must *not* enclose it in double quotes.
 
@@ -284,8 +285,9 @@ which member to proxy as. Common proxy tags include `[square brackets]`, `{curly
 To set a proxy tag, use the `pk;member proxy` command on the member in question. You'll need to provide a "proxy example", containing the word `text`.
 For example, if you want square brackets, the proxy example must be `[text]`. If you want a letter prefix, make it something like `A:text`. For example:
 
-    pk;member John proxy [text]
+    pk;member Alice proxy A:text
     pk;member "Craig Johnson" proxy {text}
+    pk;member John proxy [text]
     pk;member John proxy J:text
     
 You can have any proxy tags you want, including one containing emojis.
@@ -371,7 +373,26 @@ In other words, it means proxy tags become "sticky". This will carry over across
 To enable latch-mode autoproxying for a given server, use the following command:
 
     pk;autoproxy latch
-    
+
+To set the latched member, use their proxy tags. To disable autoproxy for a single message, start a message with one backslash (`\`). To clear the current latched member, start a message with two backslashes (`\\`).
+
+For example, using [Alice and John in the example above](#setting-up-proxy-tags):
+
+    pk;autoproxy latch
+    I haven't used a tag yet, so this message comes from @Craig#5432
+    A: hello, this is Alice via autoproxy (using an explicit prefix tag)
+    this is still Alice (using latch without tag)
+    \I'm sending this message one-off as @Craig#5432
+    but I'm still latched! (this also is sent from Alice via autoproxy)
+    [hello, this is John, using autoproxy and a surround tag]
+    still John on latch!
+    J: I could use my prefix or surround tags if I want, but don't have to
+    because the last time I used a tag, I used mine (John's)
+    \\now I'm clearing latch; this is from @Craig#5432
+    and still from @Craig#5432 because latch is cleared
+    A: but autoproxy is still on
+    so now I'm back to Alice
+
 #### Member mode 
 This autoproxy mode will autoproxy for a specific selected member, irrelevant of past proxies or fronters.
 

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -21,6 +21,8 @@ Once you go through the wizard, the bot account will automatically join the serv
 ## System management
 In order to do most things with the PluralKit bot, you'll need to have a system registered with it. A *system* is a collection of *system members* that may be used by one or more *Discord accounts*.
 
+These examples are for the user `@Craig#5432`, who has headmates Alice, Craig Johnson (formerly Craig Smith), Joanne (formerly John, aka Jo), Skyler, and Unknown.
+
 ### Creating a system
 If you do not already have a system registered, use the following command to create one:
 
@@ -34,7 +36,7 @@ Optionally, you can attach a *system name*, which will be displayed in various i
 To view information about your own system, simply type:
 
     pk;system
-    
+
 To view information about *a different* system, there are a number of ways to do so. You can either look up a system by @mention, by account ID, or by system ID. For example:
 
     pk;system @Craig#5432
@@ -67,19 +69,17 @@ a system tag. Note that emojis *are* supported! To set one, use the `pk;system t
     pk;system tag | The Boys
     pk;system tag (Test System)
     pk;system tag 🛰️
-    
+
 If you want to remove your system tag, just type `pk;system tag` with no extra parameters.
 
 **NB:** When proxying, the *total webhook username* must be 32 characters or below. As such, if you have a long system name, your tag might be enough
 to bump it over that limit. PluralKit will warn you if you have a member name/tag combination that will bring the combined username above the limit.
 You can either make the member name or the system tag shorter to solve this. 
     
-### System server tags
+#### System server tags
 If you'd like to set a system tag (as above), but only for a specific server, you can set the *system server tag*. This will override the global system tag, but only in the server you set it in. For example:
 
-```
-pk;system servertag 🛰️
-```
+    pk;system servertag 🛰️
 
 The server tag applies to the same server you run the command in, so this command doesn't function in DMs.
 
@@ -110,19 +110,19 @@ You may not remove the only account linked to a system, as that would leave the 
 ### Setting a system time zone
 PluralKit defaults to showing dates and times in [UTC](https://en.wikipedia.org/wiki/Coordinated_Universal_Time). 
 If you'd like, you can set a *system time zone*, and as such every date and time displayed in PluralKit
-(on behalf of your system) will be in the system time zone. To do so, use the `pk;system timezone` command, like so:
+(on behalf of your system) will be in the system time zone. To do so, use the `pk;config timezone` command with a time zone name, time zone code, country code, or country emoji, like so:
 
-    pk;system timezone Europe/Copenhagen
-    pk;system timezone America/New_York
-    pk;system timezone DE
-    pk;system timezone 🇬🇧
+    pk;config timezone Europe/Copenhagen
+    pk;config timezone America/New_York
+    pk;config timezone DE
+    pk;config timezone 🇬🇧
     
 You can specify time zones in various ways. In regions with large amounts of time zones (eg. the Americas, Europe, etc),
 specifying an exact time zone code is the best way. To get your local time zone code, visit [this site](https://xske.github.io/tz).
 You can see the full list [here, on Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) (see the column *TZ database name*).
 You can also search by country code, either by giving the two-character [*ISO-3166-1 alpha-2* country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements) (e.g. `GB` or `DE`), or just by a country flag emoji (e.g. `:flag_gb:` 🇬🇧 or `:flag_de:` 🇩🇪).
 
-To clear a time zone, type `pk;system timezone` without any parameters. 
+To clear a time zone, type `pk;config timezone` without any parameters. 
 
 ### Deleting a system
 If you want to delete your own system, simply use the command:
@@ -135,7 +135,7 @@ You will need to verify by typing the system's ID when the bot prompts you to - 
 
 In order to do most things related to PluralKit, you need to work with *system members*.
 
-Most member commands follow the format of `pk;member MemberName verb Parameter`. Note that if a member's name has multiple words, you'll need to enclose it in "double quotes" throughout the commands below.
+Most member commands follow the format of `pk;member MemberName verb Parameter`. Note that if a member's name has multiple words, you'll need to enclose it in "double quotes" throughout the commands below (_except_ for `pk;member new`).
 
 ### Creating a member
 You can't do much with PluralKit without having registered members with your system, but doing so is quite simple - just use the `pk;member new` command followed by the member's name, like so:
@@ -143,8 +143,14 @@ You can't do much with PluralKit without having registered members with your sys
     pk;member new John
     pk;member new Craig Smith
     pk;member new Alice
-    
-As the one exception to the rule above, if the name consists of multiple words you must *not* enclose it in double quotes.
+    pk;member new Unknown
+    pk;member new Skyler
+
+`@PluralKit` will respond with a confirmation and the member ID code, like so:
+
+    PluralKit: ✅ Member "John" (qazws) registered! 
+
+⚠️ As the one exception to the rule above, if the name consists of multiple words you must *not* enclose it in double quotes.
 
 ### Looking up member info
 To view information about a member, there are a couple ways to do it. Either you can address a member by their name (if they're in your own system), by their 5-character *member ID*, or by their *display name*, like so:
@@ -161,7 +167,15 @@ To list all the members in a system, use the `pk;system list` command. This will
     pk;system list
     pk;system @Craig#5432 list
     pk;system qazws list
-    
+
+If you run `pk;system info @Craig#5432` after the example setup so far, `@PluralKit` will output something like this:
+
+    My System Name
+    | Tag | Linked accounts       | Members (5) |
+    |-----|-----------------------|-------------|
+    |  🛰️  | Craig#5432 (@Craig 🛰️) | (see pk;system abcde list or pk;system abcde list full) |        
+    System ID: abcde | Created on 2023-03-16 00:01:52 GMT
+        
 If you want a more detailed list, with fields such as pronouns and description, add the word `full` to the end of the command, like so:
 
     pk;system list full
@@ -173,7 +187,7 @@ If you want to change the name of a member, you can use the `pk;member rename` c
 
     pk;member John rename Joanne
     pk;member "Craig Smith" rename "Craig Johnson"
-    
+
 ### Member display names
 Normally, when proxying a member, the name displayed in the proxied message will be the member's name. However, in some cases
 you may want to display a different name. For example, you may want to include a member's pronouns inside the proxied name,
@@ -182,95 +196,95 @@ indicate a subsystem, include emojis or symbols that don't play nice with the co
 In such cases you can set the member's *display name*. Which will, well, display that name instead. You can set
 a display name using the `pk;member displayname` command, like so:
 
-    pk;member John displayname Jonathan
-    pk;member Robert displayname Bob (he/him)
-    
+    pk;member Joanne displayname Jo
+    pk;member Skyler displayname Sky (they/them)
+
 To remove a display name, just use the same command with no last parameter, eg:
 
-    pk;member John displayname
-    
+    pk;member Joanne displayname
+
 This will remove the display name, and thus the member will be proxied with their canonical name.
 
-### Member server display names
+#### Member server display names
 If you'd like to set a display name (as above), but only for a specific server, you can set the member's *server display name*.
 This functions just like global display names, but only in the same server you set them in. For example:
 
-    pk;member John servername AdminJohn
+    pk;member Joanne servername AdminJo
     
 The server name applies to the same server you run the command in, so naturally this command doesn't function in DMs (as you cannot proxy in DMs).
     
 ### Member description
 In the same way as a system can have a description, so can a member. You can set a description using the `pk;member description` command, like so:
 
-    pk;member John description John is a very cool person, and you should give him hugs.
+    pk;member Joanne description Joanne is a very cool person, and you should give them hugs.
     
 As with system descriptions, the member description has a 1000 character length limit. 
-To clear a member description, use the command with no additional parameters (eg. `pk;member John description`).
+To clear a member description, use the command with no additional parameters (eg. `pk;member Joanne description`).
 
 ### Member color
 A system member can have an associated color value.
 This color is *not* displayed as a name color on proxied messages due to a Discord limitation,
 but it's shown in member cards, and it can be used in third-party apps, too.
-To set a member color, use the `pk;member color` command with [a hexadecimal color code](https://htmlcolorcodes.com/), like so:
+To set a member color, use the `pk;member color` command with [a hexadecimal color code](https://htmlcolorcodes.com/), like so, using either the member name or display name:
 
-    pk;member John color #ff0000
-    pk;member John color #87ceeb
-    
-To clear a member color, use the command with no color code argument (eg. `pk;member John color`).
+    pk;member Jo color #ff0000
+    pk;member Skyler color #87ceeb
+
+To clear a member color, use the command with no color code argument (eg. `pk;member Joanne color`).
 
 ### Member avatar
 If you want your member to have an associated avatar to display on the member information card and on proxied messages, you can set the member avatar. To do so, use the `pk;member avatar` command. You can either supply it with an direct URL to an image, or attach an image directly. For example.
 
-    pk;member John avatar http://placebeard.it/512.jpg
+    pk;member Jo avatar http://placebeard.it/512.jpg
     pk;member "Craig Johnson" avatar   (with an attached image)
     
 To preview the current avatar (if one is set), use the command with no arguments:
 
-    pk;member John avatar
+    pk;member Joanne avatar
     
-To clear your avatar, use the subcommand `avatar clear` (eg. `pk;member John avatar clear`).
+To clear your avatar, use the subcommand `avatar clear` (eg. `pk;member Joanne avatar clear`).
 
-### Member proxy avatar
+#### Member proxy avatar
 If you want your member to have a different avatar for proxies messages than the one displayed on the member card, you can set a proxy avatar. To do so, use the `pk;member proxyavatar` command, in the same way as the normal avatar command above:
 
-    pk;member John avatar
-    pk;member John proxyavatar http://placebeard.it/512.jpg
+    pk;member Joanne avatar
+    pk;member Joanne proxyavatar http://placebeard.it/512.jpg
     pk;member "Craig Johnson" proxyavatar    (with an attached image)
 
-### Member server avatar
+#### Member server avatar
 You can also set an avatar for a specific server. This will "override" the normal avatar, and will be used when proxying messages and looking up member cards in that server. To do so, use the `pk;member serveravatar` command, in the same way as the normal avatar command above:
 
-    pk;member John serveravatar
-    pk;member John serveravatar http://placebeard.it/512.jpg
+    pk;member Joanne serveravatar
+    pk;member Joanne serveravatar http://placebeard.it/512.jpg
     pk;member "Craig Johnson" serveravatar   (with an attached image)
-    pk;member John serveravatar clear
+    pk;member Joanne serveravatar clear
 
 ### Member pronouns
 If you want to list a member's preferred pronouns, you can use the pronouns field on a member profile. This is a free text field, so you can put whatever you'd like in there (with a 100 character limit), like so:
 
-    pk;member John pronouns he/him
+    pk;member Joanne pronouns she/them
     pk;member "Craig Johnson" pronouns anything goes, really
     pk;member Skyler pronouns xe/xir or they/them
 
-To remove a member's pronouns, use the command with no pronoun argument (eg. `pk;member John pronouns`).
+To remove a member's pronouns, use the command with no pronoun argument (eg. `pk;member Jo pronouns`).
 
 ### Member birthdate 
 If you want to list a member's birthdate on their information card, you can set their birthdate through PluralKit using the `pk;member birthdate` command. Please use [ISO-8601 format](https://xkcd.com/1179/) (`YYYY-MM-DD`) for best results, like so:
 
-    pk;member John birthdate 1996-07-24
+    pk;member Jo birthdate 1996-07-24
     pk;member "Craig Johnson" birthdate 2004-02-28
-    
+
 You can also set a birthdate without a year, either in `MM-DD` format or `Month Day` format, like so:
 
-    pk;member John birthdate 07-24
+    pk;member Joanne birthdate 07-24
     pk;member "Craig Johnson" birthdate Feb 28
     
-To clear a birthdate, use the command with no birthday argument (eg. `pk;member John birthdate`).
+To clear a birthdate, use the command with no birthday argument (eg. `pk;member Joanne birthdate`).
 
 ### Deleting members
 If you want to delete a member, use the `pk;member delete` command, like so:
 
-    pk;member John delete
+    pk;member Joanne delete
     
 You'll need to confirm the deletion by replying with the member's ID when the bot asks you to - this is to avoid accidental deletion.
 
@@ -287,15 +301,9 @@ To set a proxy tag, use the `pk;member proxy` command on the member in question.
 For example, if you want square brackets, the proxy example must be `[text]`. If you want a letter or emoji prefix, make it something like `A:text` or `🏳️‍🌈:text`. For example:
 
     pk;member Alice proxy ✨:text
-    pk;member Alice proxy A:text
     pk;member "Craig Johnson" proxy {text}
-    pk;member John proxy [text]
-    pk;member John proxy J:text
-
-You can now type a message enclosed in your proxy tags, and it'll be deleted by PluralKit and reposted with the appropriate member name and avatar (if set).
-
-**NB:** If you want `<angle brackets>` as proxy tags, there is currently a bug where custom server emojis will (wrongly)
-be interpreted as proxying with that member (see [issue #37](https://github.com/PluralKit/PluralKit/issues/37)). The current workaround is to use different proxy tags.
+    pk;member Jo proxy [text]
+    pk;member Skyler proxy S:text
 
 ### Using multiple distinct proxy tag pairs
 If you'd like to proxy a member in multiple ways (for example, a name or a nickname, uppercase and lowercase variants, etc), you can add multiple tag pairs.
@@ -303,18 +311,32 @@ When proxying, you may then use any of the tags to proxy for that specific membe
 
 To add a proxy tag to a member, use the `pk;member proxy add` command:
 
-    pk;member John proxy add {text}
+    pk;member Alice proxy add A:text
+    pk;member Joanne proxy add J:text
     pk;member Craig proxy add C:text
+    pk;member Unknown proxy add ?text?
+    pk;member Unknown proxy add 🤷text
+
+To make proxy tags case-insensitive, use:
+
+    pk;config proxy case off
+
+You can now type a message enclosed in / prefixed by your proxy tags, and it'll be deleted by PluralKit and reposted with the appropriate member name and avatar (if set).
+
+**NB:** If you want `<angle brackets>` as proxy tags, there is currently a bug where custom server emojis will (wrongly)
+be interpreted as proxying with that member (see [issue #37](https://github.com/PluralKit/PluralKit/issues/37)). The current workaround is to use different proxy tags.
+
+### Removing tags
     
 To remove a proxy tag from a member, use the `pk;member proxy remove` command:
 
-    pk;member John proxy remove {text}
-    pk;member Craig proxy remove C:text
+    pk;member Joanne proxy remove [text]
+    pk;member "Craig Johnson" proxy remove C:text
 
 ### Keeping your proxy tags
 If you'd like your proxied messages to include the proxy tags, you can enable the "keep proxy tags" option for a given member, like so:
 
-    pk;member John keepproxy on
+    pk;member Joanne keepproxy on
 
 Turning the option off is similar - replace "on" with "off" in the command. The default value for every member is off. When proxying
 a member with multiple proxy tags, the proxy tag used to trigger a given proxy will be included.
@@ -322,6 +344,54 @@ a member with multiple proxy tags, the proxy tag used to trigger a given proxy w
 The practical effect of this is:
 * **Keep proxy tags on:** `[Message goes here]` -> [Message goes here]
 * **Keep proxy tags off:** `[Message goes here]` -> Message goes here 
+
+## Results so far
+
+Using the examples so far (ignoring the remove commands), if you run `pk;system list @Craig#5432`, `@PluralKit` will now output something like this:
+
+    Members of My System Name (abcde)
+    [eafas] Alice (✨:text, A:text)
+    [bjeoi] Craig Johnson ({text}, C:text)
+    [qazws] Joanne (tags [text], J:text)
+    [wefje] Skyler (S:text)
+    [nxzpa] Unknown (?text?, 🤷text)
+    Sorting by name. 4 results.
+
+and `pk;system list full @Craig#5432` will output something like this:
+
+    Members of My System Name (abcde)
+
+    Alice
+    ID: eafas
+    Proxy tags: ✨:text, A:text
+
+    Craig Johnson
+    ID: bjfeoi
+    Pronouns: anything goes, really
+    Birthdate: 2004-02-28
+    Proxy tags: {text}, C:text
+
+    Joanne
+    ID: qazws
+    Display name: Jo
+    Pronouns: she/them
+    Birthdate: 1996-07-24 
+    Proxy tags: tags [text], J:text
+
+    Skyler
+    ID: wefje
+    Display name: Sky (he/him)
+    Pronouns xe/xir or they/them
+    Proxy tags: S:text
+
+    Unknown
+    ID: nxzpa
+    Proxy tags: ?text?, 🤷text
+
+    Sorting by name. 5 results.
+
+
+## Interacting with proxied messages
 
 ### Querying message information
 If you want information about a proxied message (eg. for moderation reasons), you can query the message for its sender account, system, member, etc.
@@ -361,13 +431,13 @@ To disable autoproxy for a single message, add a backslash (`\`) to the beginnin
 :::
 
 #### Front mode
-This autoproxy mode will proxy messages as the current *first* fronter of the system. If you register a switch with `Alice` and `Bob`, messages without proxy tags will be autoproxied as `Alice`.
+This autoproxy mode will proxy messages as the current *first* fronter of the system. If you register a switch with `Alice` and `Skyler`, messages without proxy tags will be autoproxied as `Alice`.
 To enable front-mode autoproxying for a given server, use the following command:
 
     pk;autoproxy front
     
 #### Latch mode
-This autoproxy mode will essentially "continue" previous proxy tags. If you proxy a message with `Alice`'s proxy tags, messages posted afterwards will be proxied as Alice. Proxying again with someone else's proxy tags, say, `Bob`, will cause messages *from then on* to be proxied as Bob.
+This autoproxy mode will essentially "continue" previous proxy tags. If you proxy a message with `Alice`'s proxy tags, messages posted afterwards will be proxied as Alice. Proxying again with someone else's proxy tags, say, `Skyler`, will cause messages *from then on* to be proxied as Skyler.
 In other words, it means proxy tags become "sticky". This will carry over across all channels in the same server.
 
 To enable latch-mode autoproxying for a given server, use the following command:
@@ -375,23 +445,6 @@ To enable latch-mode autoproxying for a given server, use the following command:
     pk;autoproxy latch
 
 To set the latched member, use their proxy tags. To disable autoproxy for a single message, start a message with one backslash (`\`). To clear the current latched member, start a message with two backslashes (`\\`).
-
-For example, using [Alice and John in the setup example above](#setting-up-proxy-tags):
-
-    pk;autoproxy latch
-    I haven't used a tag yet, so this message comes from @Craig#5432
-    ✨: hello, this is Alice via autoproxy (using an explicit prefix tag)
-    this is still Alice (using latch without tag)
-    \I'm sending this message one-off as @Craig#5432, without proxy
-    but I'm still latched! (this also is sent from Alice via autoproxy)
-    [hello, this is John, using autoproxy and a surround tag]
-    still John on latch!
-    J: I could use my prefix or surround tags if I want, but don't have to
-    because the last time I used a tag, I used mine (John's)
-    \\now I'm clearing latch; this is from @Craig#5432
-    and now new messages will be from @Craig#5432 because latch is cleared
-    A: but autoproxy is still on
-    so now I'm back to Alice
 
 #### Member mode 
 This autoproxy mode will autoproxy for a specific selected member, irrelevant of past proxies or fronters.
@@ -440,6 +493,41 @@ To re-enable autoproxy for the current account, use the following command:
 This subcommand can also be run in DMs.
 :::
 
+### Example usage
+
+For example, using [the setup example above](#setting-up-proxy-tags), `@Craig#5432` can type this:
+
+    pk;autoproxy latch
+    I haven't used a tag yet, so this message comes from @Craig#5432
+    ✨: hello, this is Alice via autoproxy (using an explicit prefix tag)
+    this is still Alice (using latch without tag)
+    \I'm sending this message one-off as @Craig#5432, without proxy
+    but I'm still latched! (this also is sent from Alice via autoproxy)
+    [hello, this is Joanne, using autoproxy and a surround tag]
+    still Jo on latch!
+    J: I could use my prefix or surround tags if I want, but don't have to
+    because the last time I used a tag, I used mine (Jo's)
+    \\now I'm clearing latch; this is from @Craig#5432
+    and now new messages will be from @Craig#5432 because latch is cleared
+    🤷 but autoproxy is still on
+    so this is Unknown
+
+and the result will look like this:
+
+    @Craig#5432: pk;autoproxy latch
+    @Craig#5432: I haven't used a tag yet, so this message comes from @Craig#5432
+    Alice: hello, this is Alice via autoproxy (using an explicit prefix tag)
+    Alice: this is still Alice (using latch without tag)
+    @Craig#5432: I'm sending this message one-off as @Craig#5432, without proxy
+    Alice: but I'm still latched! (this also is sent from Alice via autoproxy)
+    Jo: hello, this is Joanne, using autoproxy and a surround tag
+    Jo: still Jo on latch!
+    Jo: I could use my prefix or surround tags if I want, but don't have to
+    Jo: because the last time I used a tag, I used mine (Jo's)
+    @Craig#5432: now I'm clearing latch; this is from @Craig#5432
+    @Craig#5432: and now new messages will be from @Craig#5432 because latch is cleared
+    Unknown: but autoproxy is still on
+    Unknown: so this is Unknown
 
 ## Managing switches
 PluralKit allows you to log member switches through the bot.
@@ -449,8 +537,8 @@ You can then view the list of switches and fronters over time, and get statistic
 ### Logging switches
 To log a switch, use the `pk;switch` command with one or more members. For example:
 
-    pk;switch John
-    pk;switch "Craig Johnson" John
+    pk;switch Joanne
+    pk;switch "Craig Johnson" Joanne
     
 Note that the order of members are preserved (this is useful for indicating who's "more" at front, if applicable).
 If you want to specify a member with multiple words in their name, remember to encase the name in "double quotes".
@@ -534,15 +622,15 @@ This will create a new group. Groups all have a 5-letter ID, similar to systems 
 ### Adding and removing members to groups
 To add a member to a group, use the `pk;group <group> add` command, eg:
 
-    pk;group MyGroup add Craig
+    pk;group MyGroup add "Craig Johnson"
     
 You can add multiple members to a group by separating them with spaces, eg:
 
-    pk;group MyGroup add Bob John Charlie
+    pk;group MyGroup add Joanne Skyler Alice
 
 Similarly, you can remove members from a group, eg:
 
-    pk;group MyGroup remove Bob Craig
+    pk;group MyGroup remove Skyler
     
 ### Listing members in a group
 To list all the members in a group, use the `pk;group <group> list` command.
@@ -628,9 +716,9 @@ where `<member>` is the name or the id of a member in your system, `<subject>` i
 
 For example:
 
-    pk;member John privacy visibility private
+    pk;member Joanne privacy visibility private
     pk;member "Craig Johnson" privacy description public
-    pk;member Robert privacy birthday public
+    pk;member Alice privacy birthday public
     pk;member Skyler privacy all private
 
 ## Importing and exporting data

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -9,16 +9,14 @@ sidebarDepth: 1
 
 # User Guide
 
-## Adding the bot to your server
-If you want to use PluralKit on a Discord server, you must first *add* it to the server in question. For this, you'll need the *Manage Server* permission on there.
+*:information_source: You can have a space after `pk;`; e.g. `pk;system` and `pk; system` will do the same thing.*
 
-Use this link to add the bot to your server:
+## Adding the bot to your server
+If you want to use PluralKit on a Discord server, someone with *Manage Server* permission must first *add* it to the server in question, using this link:
 
 [https://discord.com/oauth2/authorize?client_id=466378653216014359&scope=bot&permissions=536995904](https://discord.com/oauth2/authorize?client_id=466378653216014359&scope=bot&permissions=536995904)
 
-Once you go through the wizard, the bot account will automatically join the server you've chosen. Please ensure the bot has the *Read Messages*, *Send Messages*, *Manage Messages*, *Attach Files* and *Manage Webhooks* permission in the channels you want it to work in. 
-
-*:information_source: You can have a space after `pk;`; e.g. `pk;system` and `pk; system` will do the same thing.*
+Once the server manager goes through the setup wizard, the bot account will automatically join the server. Please ensure the bot has the *Read Messages*, *Send Messages*, *Manage Messages*, *Attach Files* and *Manage Webhooks* permission in the channels you want it to work in. 
 
 ## System management
 In order to do most things with the PluralKit bot, you'll need to have a system registered with it. A *system* is a collection of *system members* that may be used by one or more *Discord accounts*.

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -329,7 +329,7 @@ To add a proxy tag to a member, use the `pk;member proxy add` command:
 
     pk;member Alice proxy add A:text
     pk;m Joanne proxy add J:text
-    pk;m Craig proxy add C:text
+    pk;m "Craig Johnson" proxy add C:text
     pk;m Unknown proxy add ?text?
     pk;m Unknown proxy add 🤷text
 

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -305,6 +305,10 @@ For example, if you want square brackets, the proxy example must be `[text]`. If
     pk;member Jo proxy [text]
     pk;member Skyler proxy S:text
 
+You can now type a message enclosed in / prefixed by your proxy tags, and it'll be deleted by PluralKit and reposted with the appropriate member name and avatar (if set).
+
+⚠️ Currently, you can't use `<angle brackets>` as proxy tags, due to a bug where custom server emojis will (wrongly) be interpreted as proxying with that member (see [issue #37](https://github.com/PluralKit/PluralKit/issues/37)).
+
 ### Using multiple distinct proxy tag pairs
 If you'd like to proxy a member in multiple ways (for example, a name or a nickname, uppercase and lowercase variants, etc), you can add multiple tag pairs.
 When proxying, you may then use any of the tags to proxy for that specific member.
@@ -320,11 +324,6 @@ To add a proxy tag to a member, use the `pk;member proxy add` command:
 To make proxy tags case-insensitive, use:
 
     pk;config proxy case off
-
-You can now type a message enclosed in / prefixed by your proxy tags, and it'll be deleted by PluralKit and reposted with the appropriate member name and avatar (if set).
-
-**NB:** If you want `<angle brackets>` as proxy tags, there is currently a bug where custom server emojis will (wrongly)
-be interpreted as proxying with that member (see [issue #37](https://github.com/PluralKit/PluralKit/issues/37)). The current workaround is to use different proxy tags.
 
 ### Removing tags
     
@@ -373,7 +372,7 @@ and `pk;system list full @Craig#5432` will output something like this:
 
     Joanne
     ID: qazws
-    Display name: Jo
+    Display name: AdminJo
     Pronouns: she/them
     Birthdate: 1996-07-24 
     Proxy tags: tags [text], J:text

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -120,7 +120,7 @@ If you'd like, you can set a *system time zone*, and as such every date and time
 You can specify time zones in various ways. In regions with large amounts of time zones (eg. the Americas, Europe, etc),
 specifying an exact time zone code is the best way. To get your local time zone code, visit [this site](https://xske.github.io/tz).
 You can see the full list [here, on Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) (see the column *TZ database name*).
-You can also search by country code, either by giving the two-character [*ISO-3166-1 alpha-2* country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements) (eg. `GB` or `DE`), or just by a country flag emoji.
+You can also search by country code, either by giving the two-character [*ISO-3166-1 alpha-2* country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements) (e.g. `GB` or `DE`), or just by a country flag emoji (e.g. `:flag_gb:` 🇬🇧 or `:flag_de:` 🇩🇪).
 
 To clear a time zone, type `pk;system timezone` without any parameters. 
 
@@ -283,14 +283,14 @@ You'll need to register a set of *proxy tags*, which are prefixes and/or suffixe
 which member to proxy as. Common proxy tags include `[square brackets]`, `{curly braces}` or `A:letter prefixes`.
 
 To set a proxy tag, use the `pk;member proxy` command on the member in question. You'll need to provide a "proxy example", containing the word `text`.
-For example, if you want square brackets, the proxy example must be `[text]`. If you want a letter prefix, make it something like `A:text`. For example:
 
+For example, if you want square brackets, the proxy example must be `[text]`. If you want a letter or emoji prefix, make it something like `A:text` or `🏳️‍🌈:text`. For example:
+
+    pk;member Alice proxy ✨:text
     pk;member Alice proxy A:text
     pk;member "Craig Johnson" proxy {text}
     pk;member John proxy [text]
     pk;member John proxy J:text
-    
-You can have any proxy tags you want, including one containing emojis.
 
 You can now type a message enclosed in your proxy tags, and it'll be deleted by PluralKit and reposted with the appropriate member name and avatar (if set).
 
@@ -376,20 +376,20 @@ To enable latch-mode autoproxying for a given server, use the following command:
 
 To set the latched member, use their proxy tags. To disable autoproxy for a single message, start a message with one backslash (`\`). To clear the current latched member, start a message with two backslashes (`\\`).
 
-For example, using [Alice and John in the example above](#setting-up-proxy-tags):
+For example, using [Alice and John in the setup example above](#setting-up-proxy-tags):
 
     pk;autoproxy latch
     I haven't used a tag yet, so this message comes from @Craig#5432
-    A: hello, this is Alice via autoproxy (using an explicit prefix tag)
+    ✨: hello, this is Alice via autoproxy (using an explicit prefix tag)
     this is still Alice (using latch without tag)
-    \I'm sending this message one-off as @Craig#5432
+    \I'm sending this message one-off as @Craig#5432, without proxy
     but I'm still latched! (this also is sent from Alice via autoproxy)
     [hello, this is John, using autoproxy and a surround tag]
     still John on latch!
     J: I could use my prefix or surround tags if I want, but don't have to
     because the last time I used a tag, I used mine (John's)
     \\now I'm clearing latch; this is from @Craig#5432
-    and still from @Craig#5432 because latch is cleared
+    and now new messages will be from @Craig#5432 because latch is cleared
     A: but autoproxy is still on
     so now I'm back to Alice
 

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -773,7 +773,7 @@ To update a member's privacy you can use the command:
 
     pk;member <member> privacy <subject> <level>
 
-* `<member>` is the name or the id of a member in your system
+* `<member>` is the name or the ID of a member in your system
 * `<subject>` is one of:
   * `name`
   * `description`

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -315,7 +315,7 @@ For example, if you want square brackets, the proxy example must be `[text]`. If
 
 You can now type a message enclosed in / prefixed by your proxy tags, and it'll be deleted by PluralKit and reposted with the appropriate member name and avatar (if set).
 
-*⚠️ If you use `pk;member proxy` withoug "add", it will **replace** the proxy tag(s) for that member. `@PluralKit` will respond with a warning about this, and won't do it unless you click the `Replace` button on that message.*
+*⚠️ If you use `pk;member proxy` without "add", it will **replace** the proxy tag(s) for that member. `@PluralKit` will respond with a warning about this, and won't do it unless you click the `Replace` button on that message.*
 
 *⚠️ Currently, you can't use `<angle brackets>` as proxy tags, due to a bug where custom server emojis will (wrongly) be interpreted as proxying with that member (see [issue #37](https://github.com/PluralKit/PluralKit/issues/37)).*
 

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -59,8 +59,8 @@ If you'd like to remove your system description, just type `pk;system descriptio
 ### System avatars
 If you'd like your system to have an associated "system avatar", displayed on your system information card, you can add a system avatar. To do so, use the `pk;system avatar` command. You can either supply it with an direct URL to an image, or attach an image directly. For example.
 
-    pk;s avatar http://placebeard.it/512.jpg
-    pk;system avatar [with attached image]
+    pk;system avatar http://placebeard.it/512.jpg
+    pk;s avatar [with attached image]
     
 To clear your avatar, simply type `pk;system avatar` with no attachment or link.
 
@@ -725,7 +725,7 @@ There are various reasons you may not want information about your system or your
 ### System privacy
 At the moment, there are four aspects of system privacy that can be configured.
 
-- System description
+- Description *(of system)*
 - Current fronter
 - Front history
 - Member list
@@ -736,7 +736,9 @@ To update your system privacy settings, use the following commands:
 
     pk;system privacy <subject> <level>
     
-where `<subject>` is either `description`, `fronter`, `fronthistory` or `list`, corresponding to the options above, and `<level>` is either `public` or `private`. `<subject>` can also be `all` in order to change all subjects at once.
+*  `<subject>` is either `description`, `fronter`, `fronthistory` or `list`, corresponding to the options above
+  *  (or `all` in order to change all subjects at once)
+* `<level>` is either `public` or `private`
 
 For example:
 
@@ -747,14 +749,14 @@ For example:
 When the **member list** is **private**, other users will not be able to view the full member list of your system, but they can still query individual members given their 5-letter ID. If **current fronter** is private, but **front history** isn't, someone can still see the current fronter by looking at the history (this combination doesn't make much sense).
 
 ### Member privacy
-There are also seven options for configuring member privacy;
+There are also seven options for configuring member privacy:
 
 - Name
-- Description
+- Description *(of member)*
 - Avatar
 - Birthday
 - Pronouns
-- Metadata *(message count, creation date, etc)*
+- Metadata *(message count, creation date, last message information, etc)*
 - Visibility *(whether the member shows up in member lists)*
 
 As with system privacy, each can be set to **public** or **private**. The same rules apply for how they are shown, too. When set to **public**, anyone who queries your system (by account or system ID, or through the API), will see this information. When set to **private**, the information will only be shown when *you yourself* query the information. The cards will still be displayed in the channel the commands are run in, so it's still your responsibility not to pull up information in servers where you don't want it displayed.
@@ -767,8 +769,10 @@ To update a member's privacy you can use the command:
 
     pk;member <member> privacy <subject> <level>
 
-where `<member>` is the name or the id of a member in your system, `<subject>` is either `name`, `description`, `avatar`, `birthday`, `pronouns`, `metadata`, or `visiblity` corresponding to the options above, and `<level>` is either `public` or `private`. `<subject>` can also be `all` in order to change all subjects at once.  
-`metadata` will affect the message count, the date created, the last fronted, and the last message information.
+* `<member>` is the name or the id of a member in your system
+* `<subject>` is one of `name`, `description`, `avatar`, `birthday`, `pronouns`, `metadata`, or `visiblity` corresponding to the options above
+  * (or `all` to change all subjects at once)
+* `<level>` is either `public` or `private`
 
 For example:
 

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -141,7 +141,7 @@ In order to do most things related to PluralKit, you need to work with *system m
 
 Most member commands follow the format of `pk;member MemberName verb Parameter`. Note that if a member's name has multiple words, you'll need to enclose it in "double quotes" throughout the commands below (_except_ for `pk;member new`).
 
-*:information_source: For all memer commands, you can use either the member name or display name, but not the proxy tag.*
+*:information_source: For all member commands, you can use either the member name or display name, but not the proxy tag.*
 
 ### Creating a member
 You can't do much with PluralKit without having registered members with your system, but doing so is quite simple - just use the `pk;member new` command followed by the member's name, like so:

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -312,15 +312,18 @@ For example, if you want square brackets, the proxy example must be `[text]`. If
     pk;m "Craig Johnson" proxy {text}
     pk;m Jo proxy [text]
     pk;m Skyler proxy S:text
-
+    pk;m Unknown proxy 🤷🤷text
+    
 You can now type a message enclosed in / prefixed by your proxy tags, and it'll be deleted by PluralKit and reposted with the appropriate member name and avatar (if set).
+
+*:information_source: Prefix tags don't have to use `:`. And you can have endfix-only tags if you want. `Unknown` in this example uses both. Just make sure that the tag isn't something you'll use in regular messages without intending to proxy as that member, like how `Unknown` uses a double shrug emoji for tag, rather than a single shrug that someone else might type.*
 
 *:warning: If you use `pk;member proxy` without "add", it will **replace** the proxy tag(s) for that member. PluralKit will respond with a warning about this, and won't do it unless you click the `Replace` button on that message.*
 
 *:warning: Currently, you can't use `<angle brackets>` as proxy tags, due to a bug where custom server emojis will (wrongly) be interpreted as proxying with that member (see [issue #37](https://github.com/PluralKit/PluralKit/issues/37)).*
 
 ### Using multiple distinct proxy tag pairs
-If you'd like to proxy a member in multiple ways (for example, a name or a nickname, uppercase and lowercase variants, etc), you can add multiple tag pairs.
+If you'd like to proxy a member in multiple ways (for example, a name or a nickname, uppercase and lowercase variants, etc.), you can add multiple tags.
 When proxying, you may then use any of the tags to proxy for that specific member.
 
 To add a proxy tag to a member, use the `pk;member proxy add` command:
@@ -329,7 +332,7 @@ To add a proxy tag to a member, use the `pk;member proxy add` command:
     pk;m Joanne proxy add J:text
     pk;m "Craig Johnson" proxy add C:text
     pk;m Unknown proxy add ?text?
-    pk;m Unknown proxy add 🤷text
+    pk;m Unknown proxy add text🤷🤷
 
 To make proxy tags case-insensitive, use:
 
@@ -351,8 +354,8 @@ Turning the option off is similar - replace "on" with "off" in the command. The 
 a member with multiple proxy tags, the proxy tag used to trigger a given proxy will be included.
 
 The practical effect of this is:
-* **Keep proxy tags on:** `[Message goes here]` -> [Message goes here]
-* **Keep proxy tags off:** `[Message goes here]` -> Message goes here 
+* **Keep proxy tags on:** `[Message goes here]` typed -> `[Message goes here]` displayed
+* **Keep proxy tags off:** `[Message goes here]` typed -> `Message goes here` displayed
 
 ### Disabling proxying on a per-server basis
 If you need to disable or re-enable proxying messages for your system entirely in a specific server (for example, if you'd like to
@@ -370,7 +373,7 @@ Using the examples so far (ignoring the remove commands), if you run `pk;system 
     [bjeoi] Craig Johnson ({text}, C:text)
     [qazws] Joanne (tags [text], J:text)
     [wefje] Skyler (S:text)
-    [nxzpa] Unknown (?text?, 🤷text)
+    [nxzpa] Unknown (?text?, 🤷🤷text, text🤷🤷)
     Sorting by name. 5 results.
 
 and `pk;system list full @Craig#5432` will output something like this:
@@ -402,7 +405,7 @@ and `pk;system list full @Craig#5432` will output something like this:
 
     Unknown
     ID: nxzpa
-    Proxy tags: ?text?, 🤷text
+    Proxy tags: ?text?, 🤷🤷text, text🤷🤷
 
     Sorting by name. 5 results.
 
@@ -561,7 +564,7 @@ For example, using [the setup example above](#setting-up-proxy-tags), `@Craig#54
     because the last time I used a tag, I used mine (Jo's)
     \\now I'm clearing latch; this is from @Craig#5432
     and now new messages will be from @Craig#5432 because latch is cleared
-    🤷 but autoproxy is still on
+    but autoproxy is still on🤷🤷
     so this is Unknown
 
 and the result will look like this:

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -364,7 +364,7 @@ use a different proxy bot there), you can use the commands:
     pk;system proxy off
     pk;s proxy on
 
-## Results so far
+### Results so far
 
 Using the examples so far (ignoring the remove commands), if you run `pk;system list @Craig#5432`, PluralKit will now output something like this:
 

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -121,7 +121,7 @@ If you'd like, you can set a *system time zone*, and as such every date and time
     pk;config timezone DE
     pk;config timezone 🇬🇧
 
-You can specify time zones in various ways. In regions with large amounts of time zones (eg. the Americas, Europe, etc),
+You can specify time zones in various ways. In regions with large amounts of time zones (e.g. the Americas, Europe, etc),
 specifying an exact time zone code is the best way. To get your local time zone code, visit [this site](https://xske.github.io/tz).
 You can see the full list [here, on Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) (see the column *TZ database name*).
 You can also search by country code, either by giving the two-character [*ISO-3166-1 alpha-2* country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements) (e.g. `GB` or `DE`), or just by a country flag emoji (e.g. `:flag_gb:` 🇬🇧 or `:flag_de:` 🇩🇪).
@@ -227,7 +227,7 @@ In the same way as a system can have a description, so can a member. You can set
     pk;member Joanne description Joanne is a very cool person, and you should give them hugs.
     
 As with system descriptions, the member description has a 1000 character length limit. 
-To clear a member description, use the command with no additional parameters (eg. `pk;member Joanne description`).
+To clear a member description, use the command with no additional parameters (e.g. `pk;member Joanne description`).
 
 ### Member color
 A system member can have an associated color value.
@@ -238,7 +238,7 @@ To set a member color, use the `pk;member color` command with [a hexadecimal col
     pk;member Jo color #ff0000
     pk;m Skyler color #87ceeb
 
-To clear a member color, use the command with no color code argument (eg. `pk;member Joanne color`).
+To clear a member color, use the command with no color code argument (e.g. `pk;member Joanne color`).
 
 ### Member avatar
 If you want your member to have an associated avatar to display on the member information card and on proxied messages, you can set the member avatar. To do so, use the `pk;member avatar` command. You can either supply it with an direct URL to an image, or attach an image directly. For example.
@@ -250,7 +250,7 @@ To preview the current avatar (if one is set), use the command with no arguments
 
     pk;member Joanne avatar
     
-To clear your avatar, use the subcommand `avatar clear` (eg. `pk;member Joanne avatar clear`).
+To clear your avatar, use the subcommand `avatar clear` (e.g. `pk;member Joanne avatar clear`).
 
 #### Member proxy avatar
 If you want your member to have a different avatar for proxies messages than the one displayed on the member card, you can set a proxy avatar. To do so, use the `pk;member proxyavatar` command, in the same way as the normal avatar command above:
@@ -274,7 +274,7 @@ If you want to list a member's preferred pronouns, you can use the pronouns fiel
     pk;m "Craig Johnson" pronouns anything goes, really
     pk;m Skyler pronouns xe/xir, he/him, or they/them
 
-To remove a member's pronouns, use the command with no pronoun argument (eg. `pk;member Jo pronouns`).
+To remove a member's pronouns, use the command with no pronoun argument (e.g. `pk;member Jo pronouns`).
 
 ### Member birthdate 
 If you want to list a member's birthdate on their information card, you can set their birthdate through PluralKit using the `pk;member birthdate` command. Please use [ISO-8601 format](https://xkcd.com/1179/) (`YYYY-MM-DD`) for best results, like so:
@@ -287,7 +287,7 @@ You can also set a birthdate without a year, either in `MM-DD` format or `Month 
     pk;member Joanne birthdate 07-24
     pk;m "Craig Johnson" birthdate Feb 28
     
-To clear a birthdate, use the command with no birthday argument (eg. `pk;member Joanne birthdate`).
+To clear a birthdate, use the command with no birthday argument (e.g. `pk;member Joanne birthdate`).
 
 ### Deleting members
 If you want to delete a member, use the `pk;member delete` command, like so:
@@ -453,7 +453,7 @@ been sent from your own account.
 ### Anyone's messages
 
 #### Querying message information
-If you want information about a proxied message (eg. for moderation reasons), you can query the message for its sender account, system, member, etc.
+If you want information about a proxied message (e.g. for moderation reasons), you can query the message for its sender account, system, member, etc.
 
 You can
 * react to the message itself with the `:grey_question:` :grey_question: or `:question:` :question: emoji, which will DM you information about the message in question,
@@ -779,7 +779,7 @@ For example:
     pk;m Skyler privacy all private
 
 ## Importing and exporting data
-If you're a user of another proxy bot (eg. Tupperbox), or you want to import a saved system backup, you can use the importing and exporting commands.
+If you're a user of another proxy bot (e.g. Tupperbox), or you want to import a saved system backup, you can use the importing and exporting commands.
 
 ### Importing from Tupperbox
 If you're a user of the *other proxying bot* Tupperbox, you can import system and member information from there. This is a fairly simple process:

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -300,10 +300,12 @@ If you'd like to proxy a member in multiple ways (for example, a name or a nickn
 When proxying, you may then use any of the tags to proxy for that specific member.
 
 To add a proxy tag to a member, use the `pk;member proxy add` command:
+
     pk;member John proxy add {text}
     pk;member Craig proxy add C:text
     
 To remove a proxy tag from a member, use the `pk;member proxy remove` command:
+
     pk;member John proxy remove {text}
     pk;member Craig proxy remove C:text
 


### PR DESCRIPTION
I've:
* fixed typos and display errors (e.g. code blocks and "e.g.")
* simplified or clarified various wording
* added better examples of emoji based tags, and spelled out emoji
* made the examples use a consistent set of names, pronouns, etc. (including respecting the example name changes, display names, keepproxy, etc) and fixed conflicting or inconsistent examples (e.g. John & Craig both having `{text}`)
* fixed incorrect `pk;system timezone` to `pk;config timezone`
* added documentation and examples for 
  * unlatch
  * edit
  * reproxy
  * case-insensitive proxy tags
  * non-`:` prefix, postfix, emoji, & non-bracket-like proxy tags
  * reply-based message query
  * all the shorthand commands except `pk;cfg`
  * `pk; command` being okay
* added warning notices about limitations of some commands, e.g. edit & reproxy timeouts, based on [code](https://github.com/PluralKit/PluralKit/blob/631c6027aba61f85c8f43f4abb8416cc14d1ccb0/PluralKit.Bot/Commands/Message.cs#L211) and some basic testing
* added warning notice about how `pk;m proxy` will require verification if it's replacing rather than adding
* added fully worked examples of this in use, including both usage and PluralKit responses
* added covering sections or moved special cases to subsections