### PR TITLE
feat: per-server keepproxy toggling

### DIFF
--- a/PluralKit.Bot/CommandMeta/CommandHelp.cs
+++ b/PluralKit.Bot/CommandMeta/CommandHelp.cs
@@ -54,6 +54,7 @@ public partial class CommandTree
     public static Command MemberServerName = new Command("member servername", "member <member> servername [server name]", "Changes a member's display name in the current server");
     public static Command MemberAutoproxy = new Command("member autoproxy", "member <member> autoproxy [on|off]", "Sets whether a member will be autoproxied when autoproxy is set to latch or front mode.");
     public static Command MemberKeepProxy = new Command("member keepproxy", "member <member> keepproxy [on|off]", "Sets whether to include a member's proxy tags when proxying");
+    public static Command MemberServerKeepProxy = new Command("member server keepproxy", "member <member> serverkeepproxy [on|off]", "Sets whether to include a member's proxy tags when proxying in the current server.");
     public static Command MemberRandom = new Command("system random", "system [system] random", "Shows the info card of a randomly selected member in a system.");
     public static Command MemberId = new Command("member id", "member [member] id", "Prints a member's id.");
     public static Command MemberPrivacy = new Command("member privacy", "member <member> privacy <name|description|birthday|pronouns|metadata|visibility|all> <public|private>", "Changes a members's privacy settings");

--- a/PluralKit.Bot/CommandMeta/CommandTree.cs
+++ b/PluralKit.Bot/CommandMeta/CommandTree.cs
@@ -336,6 +336,8 @@ public partial class CommandTree
             await ctx.Execute<MemberEdit>(MemberAutoproxy, m => m.MemberAutoproxy(ctx, target));
         else if (ctx.Match("keepproxy", "keeptags", "showtags", "kp"))
             await ctx.Execute<MemberEdit>(MemberKeepProxy, m => m.KeepProxy(ctx, target));
+        else if (ctx.Match("serverkeepproxy", "servershowtags", "guildshowtags", "guildkeeptags", "serverkeeptags", "skp"))
+            await ctx.Execute<MemberEdit>(MemberServerKeepProxy, m => m.ServerKeepProxy(ctx, target));
         else if (ctx.Match("id"))
             await ctx.Execute<Member>(MemberId, m => m.DisplayId(ctx, target));
         else if (ctx.Match("privacy"))

--- a/PluralKit.Bot/Proxy/ProxyMatch.cs
+++ b/PluralKit.Bot/Proxy/ProxyMatch.cs
@@ -9,13 +9,22 @@ public struct ProxyMatch
     public string? Content;
     public ProxyTag? ProxyTags;
 
+    private bool ShouldKeepProxy()
+    {
+        if (Member.ServerKeepProxy != null && Member.ServerKeepProxy.Value)
+            return true;
+        else if (Member.KeepProxy && !(Member.ServerKeepProxy != null && !Member.ServerKeepProxy.Value))
+            return true;
+        else return false;
+    }
+
     public string? ProxyContent
     {
         get
         {
             // Add the proxy tags into the proxied message if that option is enabled
             // Also check if the member has any proxy tags - some cases autoproxy can return a member with no tags
-            if (Member.KeepProxy && Content != null && ProxyTags != null)
+            if (ShouldKeepProxy() && ProxyTags != null && Content != null)
                 return $"{ProxyTags.Value.Prefix}{Content}{ProxyTags.Value.Suffix}";
 
             return Content;

--- a/PluralKit.Core/Database/Functions/ProxyMember.cs
+++ b/PluralKit.Core/Database/Functions/ProxyMember.cs
@@ -17,6 +17,7 @@ public class ProxyMember
     public MemberId Id { get; }
     public IReadOnlyCollection<ProxyTag> ProxyTags { get; } = new ProxyTag[0];
     public bool KeepProxy { get; }
+    public bool? ServerKeepProxy { get; }
 
     public string? ServerName { get; }
     public string? DisplayName { get; }

--- a/PluralKit.Core/Database/Functions/functions.sql
+++ b/PluralKit.Core/Database/Functions/functions.sql
@@ -68,6 +68,7 @@ create function proxy_members(account_id bigint, guild_id bigint)
         id int,
         proxy_tags proxy_tag[],
         keep_proxy bool,
+        server_keep_proxy bool,
 
         server_name text,
         display_name text,
@@ -87,6 +88,7 @@ as $$
         members.id                   as id,
         members.proxy_tags           as proxy_tags,
         members.keep_proxy           as keep_proxy,
+        member_guild.keep_proxy     as server_keep_proxy,
 
         -- Name info
         member_guild.display_name    as server_name,

--- a/PluralKit.Core/Database/Migrations/37.sql
+++ b/PluralKit.Core/Database/Migrations/37.sql
@@ -1,0 +1,5 @@
+-- database version 37
+-- add per-server keepproxy toggle
+
+alter table member_guild add column keep_proxy bool default null;
+update info set schema_version = 37;

--- a/PluralKit.Core/Database/Utils/DatabaseMigrator.cs
+++ b/PluralKit.Core/Database/Utils/DatabaseMigrator.cs
@@ -9,7 +9,7 @@ namespace PluralKit.Core;
 internal class DatabaseMigrator
 {
     private const string RootPath = "PluralKit.Core.Database"; // "resource path" root for SQL files
-    private const int TargetSchemaVersion = 36;
+    private const int TargetSchemaVersion = 37;
     private readonly ILogger _logger;
 
     public DatabaseMigrator(ILogger logger)

--- a/PluralKit.Core/Models/MemberGuildSettings.cs
+++ b/PluralKit.Core/Models/MemberGuildSettings.cs
@@ -9,6 +9,7 @@ public class MemberGuildSettings
     public ulong Guild { get; }
     public string? DisplayName { get; }
     public string? AvatarUrl { get; }
+    public bool? KeepProxy { get; }
 }
 
 public static class MemberGuildExt
@@ -19,6 +20,7 @@ public static class MemberGuildExt
 
         o.Add("display_name", settings.DisplayName);
         o.Add("avatar_url", settings.AvatarUrl);
+        o.Add("keep_proxy", settings.KeepProxy);
 
         return o;
     }

--- a/PluralKit.Core/Models/Patch/MemberGuildPatch.cs
+++ b/PluralKit.Core/Models/Patch/MemberGuildPatch.cs
@@ -10,10 +10,12 @@ public class MemberGuildPatch: PatchObject
 {
     public Partial<string?> DisplayName { get; set; }
     public Partial<string?> AvatarUrl { get; set; }
+    public Partial<bool?> KeepProxy { get; set; }
 
     public override Query Apply(Query q) => q.ApplyPatch(wrapper => wrapper
         .With("display_name", DisplayName)
         .With("avatar_url", AvatarUrl)
+        .With("keep_proxy", KeepProxy)
     );
 
     public new void AssertIsValid()
@@ -36,6 +38,9 @@ public class MemberGuildPatch: PatchObject
         if (o.ContainsKey("avatar_url"))
             patch.AvatarUrl = o.Value<string>("avatar_url").NullIfEmpty();
 
+        if (o.ContainsKey("keep_proxy"))
+            patch.KeepProxy = o.Value<bool>("keep_proxy");
+
         return patch;
     }
 
@@ -50,6 +55,9 @@ public class MemberGuildPatch: PatchObject
 
         if (AvatarUrl.IsPresent)
             o.Add("avatar_url", AvatarUrl.Value);
+
+        if (KeepProxy.IsPresent)
+            o.Add("keep_proxy", KeepProxy.Value);
 
         return o;
     }

--- a/docs/content/command-list.md
+++ b/docs/content/command-list.md
@@ -92,6 +92,7 @@ You can have a space after `pk;`, e.g. `pk;system` and `pk; system` will do the 
 - `pk;member <member> proxy remove [tags]` - Removes a proxy tag from a member.
 - `pk;member <member> autoproxy [on|off]` - Sets whether a member will be autoproxied when autoproxy is set to latch or front mode.
 - `pk;member <member> keepproxy [on|off]` - Sets whether to include a member's proxy tags in the proxied message.
+- `pk;member <member> serverkeepproxy [on|off]` - Sets whether to include a member's proxy tag in the proxied message in a specific server.
 - `pk;member <member> pronouns [pronouns]` - Changes the pronouns of a member.
 - `pk;member <member> color [color]` - Changes the color of a member.
 - `pk;member <member> birthdate [birthdate|today]` - Changes the birthday of a member.


### PR DESCRIPTION
adds a `pk;m <member> serverkeepproxy on|off` command (`skp` for short) that enables/disables keepproxy on a per-server basis. Overrides the global keepproxy setting, and is clearable with `pk;m <member> skp clear`.