### PR TITLE
Update dashboard with new privacy features + then some

### DIFF
--- a/dashboard/src/api/index.ts
+++ b/dashboard/src/api/index.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import * as Sentry from '@sentry/browser';
 
-const baseUrl = () => localStorage.isBeta ? "https://api.beta.pluralkit.me" : "https://api.pluralkit.me";
+let baseUrl = () => localStorage.getItem("pk_api_url") ? localStorage.pk_api_url : localStorage.isBeta ? "https://api.beta.pluralkit.me" : "https://api.pluralkit.me";
 
 const methods = ['get', 'post', 'delete', 'patch', 'put'];
 const noop = () => {};

--- a/dashboard/src/api/types.ts
+++ b/dashboard/src/api/types.ts
@@ -5,6 +5,8 @@ export interface SystemPrivacy {
     front_history_privacy?: string,
     group_list_privacy?: string,
     pronoun_privacy?: string,
+    avatar_privacy?: string,
+    name_privacy?: string
 }
 
 export interface System {
@@ -40,7 +42,8 @@ export interface MemberPrivacy {
     birthday_privacy?: string,
     pronoun_privacy?: string,
     avatar_privacy?: string,
-    metadata_privacy?: string
+    metadata_privacy?: string,
+    proxy_privacy?: string
 }
 
 interface proxytag {

--- a/dashboard/src/components/member/Privacy.svelte
+++ b/dashboard/src/components/member/Privacy.svelte
@@ -34,6 +34,7 @@
 		name_privacy: "Name",
 		pronoun_privacy: "Pronouns",
 		visibility: "Visibility",
+        proxy_privacy: "Proxy Tags"
 	};
 
     async function submit() {

--- a/dashboard/src/components/system/Privacy.svelte
+++ b/dashboard/src/components/system/Privacy.svelte
@@ -17,7 +17,9 @@
         front_privacy: "Front",
         front_history_privacy: "Front history",
         group_list_privacy: "Group list",
-        pronoun_privacy: "Pronouns"
+        pronoun_privacy: "Pronouns",
+        avatar_privacy: "Avatar",
+        name_privacy: "Name"
 	};
 
 </script>

--- a/dashboard/src/components/system/PrivacyEdit.svelte
+++ b/dashboard/src/components/system/PrivacyEdit.svelte
@@ -25,7 +25,9 @@
         front_privacy: "Front",
         front_history_privacy: "Front history",
         group_list_privacy: "Group list",
-        pronoun_privacy: "Pronouns"
+        pronoun_privacy: "Pronouns",
+        avatar_privacy: "Avatar",
+        name_privacy: "Name"
 	};
 
     async function submit() {

--- a/dashboard/src/routes/Dash/Profile.svelte
+++ b/dashboard/src/routes/Dash/Profile.svelte
@@ -47,7 +47,7 @@
 
     async function getSystem() {
         try {
-            let res: System = await api().systems(systemId).get();
+            let res: System = await api().systems(systemId).get({ auth: false });
             user = res;
             title = user.name ? user.name : "system";
         } catch (error) {
@@ -73,7 +73,7 @@
         loading.groups = true;
 
         try {
-            const res = await api().systems(systemId).members.get();
+            const res = await api().systems(systemId).members.get({ auth: false });
             memberStore.set(res)
             loading.members = false;
 
@@ -83,7 +83,7 @@
         }
 
         try {
-            const res = await api().systems(systemId).groups.get();
+            const res = await api().systems(systemId).groups.get({ auth: false });
             groupStore.set(res)
             loading.groups = false;
 

--- a/dashboard/src/routes/Dash/System/BulkMemberPrivacy.svelte
+++ b/dashboard/src/routes/Dash/System/BulkMemberPrivacy.svelte
@@ -23,6 +23,7 @@
 		pronoun_privacy: "no change",
 		visibility: "no change",
 		metadata_privacy: "no change",
+		proxy_privacy: "no change",
 	};
 
 	const privacyNames: { [P in keyof MemberPrivacy]-?: string; } = {
@@ -33,6 +34,7 @@
 		name_privacy: "Name",
 		pronoun_privacy: "Pronouns",
 		visibility: "Visibility",
+		proxy_privacy: "Proxy Tags"
 	};
 
 	async function submit() {


### PR DESCRIPTION
Mostly does what it says on the tin. There's a couple other things in here, but they're just the following
- setting a localstorage item with the key `pk_api_url` will now override the api base URL to the value of that item (there's no way to do this through the dashboard, this is mostly for dev environments)
- the public section's system tab and both lists should now correctly only show private info when viewing your own system while logged in! 