### PR TITLE
Serverkeepproxy documentation changes

### DIFF
--- a/PluralKit.Bot/CommandMeta/CommandHelp.cs
+++ b/PluralKit.Bot/CommandMeta/CommandHelp.cs
@@ -55,7 +55,7 @@ public partial class CommandTree
     public static Command MemberAutoproxy = new Command("member autoproxy", "member <member> autoproxy [on|off]", "Sets whether a member will be autoproxied when autoproxy is set to latch or front mode.");
     public static Command MemberKeepProxy = new Command("member keepproxy", "member <member> keepproxy [on|off]", "Sets whether to include a member's proxy tags when proxying");
     public static Command MemberTts = new Command("member text-to-speech", "member <member> text-to-speech [on|off]", "Sets whether to send a member's messages as text-to-speech messages.");
-    public static Command MemberServerKeepProxy = new Command("member server keepproxy", "member <member> serverkeepproxy [on|off]", "Sets whether to include a member's proxy tags when proxying in the current server.");
+    public static Command MemberServerKeepProxy = new Command("member server keepproxy", "member <member> serverkeepproxy [on|off|clear]", "Sets whether to include a member's proxy tags when proxying in the current server.");
     public static Command MemberRandom = new Command("system random", "system [system] random", "Shows the info card of a randomly selected member in a system.");
     public static Command MemberId = new Command("member id", "member [member] id", "Prints a member's id.");
     public static Command MemberPrivacy = new Command("member privacy", "member <member> privacy <name|description|birthday|pronouns|metadata|visibility|all> <public|private>", "Changes a members's privacy settings");

--- a/PluralKit.Bot/Commands/MemberEdit.cs
+++ b/PluralKit.Bot/Commands/MemberEdit.cs
@@ -519,9 +519,9 @@ public class MemberEdit
                 keepProxyStatusMessage += "This member has keepproxy **disabled**. Proxy tags will **not** be included in the resulting message when proxying.";
 
             if (memberGuildConfig.KeepProxy.HasValue && memberGuildConfig.KeepProxy.Value)
-                keepProxyStatusMessage += $"\n{Emojis.Warn} This member has keepproxy **enabled in this server**, which means proxy tags will **always** be included when proxying in this server, regardless of the global keepproxy.";
+                keepProxyStatusMessage += $"\n{Emojis.Warn} This member has keepproxy **enabled in this server**, which means proxy tags will **always** be included when proxying in this server, regardless of the global keepproxy. To clear this setting in this server, type `pk;m <member> serverkeepproxy clear`.";
             else if (memberGuildConfig.KeepProxy.HasValue && !memberGuildConfig.KeepProxy.Value)
-                keepProxyStatusMessage += $"\n{Emojis.Warn} This member has keepproxy **disabled in this server**, which means proxy tags will **never** be included when proxying in this server, regardless of the global keepproxy.";
+                keepProxyStatusMessage += $"\n{Emojis.Warn} This member has keepproxy **disabled in this server**, which means proxy tags will **never** be included when proxying in this server, regardless of the global keepproxy. To clear this setting in this server, type `pk;m <member> serverkeepproxy clear`.";
 
             await ctx.Reply(keepProxyStatusMessage);
             return;
@@ -540,9 +540,9 @@ public class MemberEdit
             keepProxyUpdateMessage += $"{Emojis.Success} this member now has keepproxy **disabled**. Member proxy tags will be **included** in the resulting message when proxying.";
 
         if (memberGuildConfig.KeepProxy.HasValue && memberGuildConfig.KeepProxy.Value)
-            keepProxyUpdateMessage += $"\n{Emojis.Warn} This member has keepproxy **enabled in this server**, which means proxy tags will **always** be included when proxying in this server, regardless of the global keepproxy.";
+            keepProxyUpdateMessage += $"\n{Emojis.Warn} This member has keepproxy **enabled in this server**, which means proxy tags will **always** be included when proxying in this server, regardless of the global keepproxy. To clear this setting in this server, type `pk;m <member> serverkeepproxy clear`.";
         else if (memberGuildConfig.KeepProxy.HasValue && !memberGuildConfig.KeepProxy.Value)
-            keepProxyUpdateMessage += $"\n{Emojis.Warn} This member has keepproxy **disabled in this server**, which means proxy tags will **never** be included when proxying in this server, regardless of the global keepproxy.";
+            keepProxyUpdateMessage += $"\n{Emojis.Warn} This member has keepproxy **disabled in this server**, which means proxy tags will **never** be included when proxying in this server, regardless of the global keepproxy. To clear this setting in this server, type `pk;m <member> serverkeepproxy clear`.";
 
         await ctx.Reply(keepProxyUpdateMessage);
     }
@@ -569,17 +569,17 @@ public class MemberEdit
         }
         else if (ctx.HasNext())
         {
-            throw new PKSyntaxError("You must pass either \"on\" or \"off\".");
+            throw new PKSyntaxError("You must pass either \"on\", \"off\" or \"clear\".");
         }
         else
         {
             if (memberGuildConfig.KeepProxy.HasValue)
                 if (memberGuildConfig.KeepProxy.Value)
                     await ctx.Reply(
-                        "This member has keepproxy **enabled** in the current server, which means proxy tags will be **included** in the resulting message when proxying.");
+                        "This member has keepproxy **enabled** in the current server, which means proxy tags will be **included** in the resulting message when proxying. To clear this setting in this server, type `pk;m <member> serverkeepproxy clear`.");
                 else
                     await ctx.Reply(
-                        "This member has keepproxy **disabled** in the current server, which means proxy tags will **not** be included in the resulting message when proxying.");
+                        "This member has keepproxy **disabled** in the current server, which means proxy tags will **not** be included in the resulting message when proxying. To clear this setting in this server, type `pk;m <member> serverkeepproxy clear`.");
             else
             {
                 var noServerKeepProxySetMessage = "This member does not have a server keepproxy override set.";
@@ -599,10 +599,10 @@ public class MemberEdit
         if (newValue.HasValue)
             if (newValue.Value)
                 await ctx.Reply(
-                    $"{Emojis.Success} Member proxy tags will now be **included** in the resulting message when proxying **in the current server**.");
+                    $"{Emojis.Success} Member proxy tags will now be **included** in the resulting message when proxying **in the current server**. To clear this setting in this server, type `pk;m <member> serverkeepproxy clear`.");
             else
                 await ctx.Reply(
-                    $"{Emojis.Success} Member proxy tags will now **not** be included in the resulting message when proxying **in the current server**.");
+                    $"{Emojis.Success} Member proxy tags will now **not** be included in the resulting message when proxying **in the current server**. To clear this setting in this server, type `pk;m <member> serverkeepproxy clear`.");
         else
         {
             var serverKeepProxyClearedMessage = $"{Emojis.Success} Cleared server keepproxy settings for this member.";

--- a/docs/content/api/models.md
+++ b/docs/content/api/models.md
@@ -154,3 +154,4 @@ Every PluralKit entity has two IDs: a short (5-character) ID and a longer UUID. 
 |guild_id|snowflake|only sent if the guild ID isn't already known (in dispatch payloads)|
 |display_name|?string|100-character limit|
 |avatar_url|?string|256-character limit, must be a publicly-accessible URL|
+|keep_proxy|?boolean||

--- a/docs/content/command-list.md
+++ b/docs/content/command-list.md
@@ -92,7 +92,7 @@ You can have a space after `pk;`, e.g. `pk;system` and `pk; system` will do the 
 - `pk;member <member> proxy remove [tags]` - Removes a proxy tag from a member.
 - `pk;member <member> autoproxy [on|off]` - Sets whether a member will be autoproxied when autoproxy is set to latch or front mode.
 - `pk;member <member> keepproxy [on|off]` - Sets whether to include a member's proxy tags in the proxied message.
-- `pk;member <member> serverkeepproxy [on|off]` - Sets whether to include a member's proxy tag in the proxied message in a specific server.
+- `pk;member <member> serverkeepproxy [on|off|clear]` - Sets whether to include a member's proxy tag in the proxied message in a specific server.
 - `pk;member <member> tts [on|off]` - Sets whether to send a member's messages as text-to-speech messages.
 - `pk;member <member> pronouns [pronouns]` - Changes the pronouns of a member.
 - `pk;member <member> color [color]` - Changes the color of a member.


### PR DESCRIPTION
I realized I'd forgotten to include server keepproxy in the api docs, and how to clear the server keepproxy wasn't entirely obvious. This is a quick fix for both, feel free to change the wording.