### PR TITLE
table format fix

### DIFF
--- a/docs/content/tips-and-tricks.md
+++ b/docs/content/tips-and-tricks.md
@@ -79,7 +79,7 @@ You cannot look up private members or groups of another system.
 |pk;edit|-prepend|-p|Prepend the new content to the old message instead of overwriting it|
 |pk;edit|-nospace|-ns|Append/prepend without adding a space|
 |pk;edit|-clear-embed|-ce|Remove embeds from a message|
-|pk;edit|-regex|-x|Edit using a C# Regex formatted like s|X|Y or s|X|Y|F, where | is any character, X is a Regex, Y is a substitution string, and F is a set of Regex flags|
+|pk;edit|-regex|-x|Edit using a C# Regex formatted like s\|X\|Y or s\|X\|Y\|F, where \| is any character, X is a Regex, Y is a substitution string, and F is a set of Regex flags|
 |Most commands|-all|-a|Show hidden/private information|
 |Most commands|-raw|-r|Show text with formatting, for easier copy-pasting|
 |All commands|-private|-priv|Show private information|


### PR DESCRIPTION
The row about regex in misc flags table of `docs/content/tips-and-tricks.md` was missing part of it's last column due to some unescaped pipes.



(this is my first pull request, let me know if I've done something wrong)