### PR TITLE
Fix avatar size restrictions in documentation. (Closes #590)

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -61,7 +61,7 @@ If you don't have a link, you can leave that out entirely, and then **attach** t
 Avatars have some restrictions: 
 - The image must be in **.jpg**, **.png**, or **.webp** format
 - The image must be under **1024 KB** in size
-- The image must be below **1024 x 1024 pixels** in resolution (along the smallest axis).
+- The image must be below **1000 x 1000 pixels** in resolution (along the smallest axis).
 - Animated GIFs are **not** supported (even if you have Nitro).
 :::
 


### PR DESCRIPTION
The docs currently specify that avatar images must be below 1024x1024 pixels. In practice Pluralkit throws an error for images greater than 1000x1000 pixels. This change just updates the documentation to match what the code has implemented.