### PR TITLE
feat(api): add endpoint for latch clear

### DIFF
--- a/docs/content/api/endpoints.md
+++ b/docs/content/api/endpoints.md
@@ -94,6 +94,24 @@ Returns an [autoproxy settings](/api/models/#autoproxy-settings-model) object on
 Currently, only autoproxy with `guild_id` is supported. The API will return an error message if you specify `channel_id`, or do not specify a `guild_id`.
 :::
 
+### Clear System Autoproxy Latch
+
+POST `/systems/@me/autoproxy/unlatch`
+
+Query String Parameters
+|name|type|
+|---|---|
+|guild_id?|snowflake|
+|channel_id?|snowflake|
+
+If autoproxy latch is enabled: clear latch status, without disabling autoproxy.  If autoproxy latch is not enabled, this endpoint is a no-op.
+
+Returns 204 No Content on success.
+
+::: warning
+Currently, only autoproxy with `guild_id` is supported. The API will return an error message if you specify `channel_id`, or do not specify a `guild_id`.
+:::
+
 ---
 ## Members
 

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -61,6 +61,7 @@ async fn main() -> anyhow::Result<()> {
 
         .route("/v2/systems/:system_id/autoproxy", get(util::rproxy))
         .route("/v2/systems/:system_id/autoproxy", patch(util::rproxy))
+        .route("/v2/systems/:system_id/autoproxy/unlatch", post(util::rproxy))
 
         .route("/v2/messages/:message_id", get(util::rproxy))
 


### PR DESCRIPTION
## What changes are in this PR?
- Adds a `/systems/@me/autoproxy/unlatch`endpoint, as an API equivalent to the existing `\\` message command
- Adds documentation for the endpoint

## Why is this useful?
My system also uses and contributes to [Séance](https://github.com/Qyriad/Seance), and though we like to keep things *mostly* consistent, situations arise where not all of our bot instances are in every server, so we end up using both PluralKit and Séance in the same channels, and managing autoproxy between both of those can get kind of messy.

When we switch from using a Séance instance to Pluralkit that goes fine - our fork's autoproxy implementation in Séance is built with the assumption that there will be other bot instances, so we just need to make sure the "peer pattern" regex each bot has also covers our Pluralkit message patterns.  But at the moment, there is no way for Pluralkit to know that it should unlatch when a Séance instance starts proxying.  Adding this endpoint will allow us to build that functionality into Séance, giving us a bit of an easier time in servers where we're using both.

This is admittedly a bit of an out-there edge use case, but as it's functionality the bot already had, I figured adding an API endpoint to expose that functionality programmatically would not be an issue.

### Potential other options
We could *theoretically* get the behavior we need by querying the current autoproxy state, turning autoproxy off, and then putting it back . . . but that would mean making three API requests in quick succession, which would exceed your rate limit

For a while I thought maybe I'd be able to send a PATCH request to the existing `/systems/@me/autoproxy` endpoint to just reset the latch state, but it doesn't appear to work that way and it seemed like better API design to give this its own endpoint if we were going to add the functionality in

## Potential issues
With the way I've got my code right now, the API routing itself *does* allow for GET and PATCH requests to the `unlatch` endpoint, and POST requests to the base `autoproxy` endpoint.  As it looks like you're running the API behind a Rust proxy I figured that would be fine, and I preferred to follow the code pattern you've already got in place for routing (I'm not *super* familiar with .NET so extending it was beyond the scope of what I could do myself easily), but if that's a problem let me know