### PR TITLE
Updating webhook.Length check and error message from 10 -> 15

### DIFF
--- a/PluralKit.Bot/Services/WebhookCacheService.cs
+++ b/PluralKit.Bot/Services/WebhookCacheService.cs
@@ -94,9 +94,9 @@ public class WebhookCacheService
 
         // We don't have one, so we gotta create a new one
         // but first, make sure we haven't hit the webhook cap yet...
-        if (webhooks.Length >= 10)
+        if (webhooks.Length >= 15)
             throw new PKError(
-                "This channel has the maximum amount of possible webhooks (10) already created. A server admin must delete one or more webhooks so PluralKit can create one for proxying.");
+                "This channel has the maximum amount of possible webhooks (15) already created. A server admin must delete one or more webhooks so PluralKit can create one for proxying.");
 
         return await DoCreateWebhook(channelId);
     }


### PR DESCRIPTION
According to the [Discord developer docs](https://discord.com/developers/docs/topics/opcodes-and-status-codes), the webhook limit per channel is now 15 rather than 10. This PR updates the check for the webhook limit and it's associated error message.

(Haven't PR'd in ages, hope I did it right, LOL)