### PR TITLE
Removes the '@mention' instruction from ShowBannerImage

### DIFF
--- a/PluralKit.Bot/Commands/MemberEdit.cs
+++ b/PluralKit.Bot/Commands/MemberEdit.cs
@@ -213,7 +213,7 @@ public class MemberEdit
             else
             {
                 throw new PKSyntaxError(
-                    "This member does not have a banner image set. Set one by attaching an image to this command, or by passing an image URL or @mention.");
+                    "This member does not have a banner image set. Set one by attaching an image to this command, or by passing an image URL.");
             }
         }
 


### PR DESCRIPTION
Correcting a copy/paste mistake from the Avatar handling. Banners cannot accept a Discord @mention (i.e., a user profile) as a URL, unlike Avatars.