### PR TITLE
Expand error message when reaching/hitting member limit to include server

### DIFF
--- a/PluralKit.Bot/Commands/Member.cs
+++ b/PluralKit.Bot/Commands/Member.cs
@@ -109,10 +109,10 @@ public class Member
                 $"{Emojis.Note} Note that this member's name contains spaces. You will need to surround it with \"double quotes\" when using commands referring to it, or just use the member's 5-character ID (which is `{member.Hid}`).");
         if (memberCount >= memberLimit)
             await ctx.Reply(
-                $"{Emojis.Warn} You have reached the per-system member limit ({memberLimit}). You will be unable to create additional members until existing members are deleted.");
+                $"{Emojis.Warn} You have reached the per-system member limit ({memberLimit}). If you need to add more members, you can either delete existing members, or ask for your limit to be raised in the PluralKit support server: <https://discord.gg/PczBt78>");
         else if (memberCount >= Limits.WarnThreshold(memberLimit))
             await ctx.Reply(
-                $"{Emojis.Warn} You are approaching the per-system member limit ({memberCount} / {memberLimit} members). Please review your member list for unused or duplicate members.");
+                $"{Emojis.Warn} You are approaching the per-system member limit ({memberCount} / {memberLimit} members). Once you reach this limit, you will be unable to create new members until existing members are deleted, or you can ask for your limit to be raised in the PluralKit support server: <https://discord.gg/PczBt78>");
     }
 
     public async Task ViewMember(Context ctx, PKMember target)


### PR DESCRIPTION
This commit adds extra instruction when reaching and when hitting the member limits to join the support server to ask for a raise. Please feel free to adjust my wording.

Group change will be separate.