### PR TITLE
Correcting inconsistencies in group avatar/banner messages

### DIFF
--- a/PluralKit.Bot/Commands/Groups.cs
+++ b/PluralKit.Bot/Commands/Groups.cs
@@ -300,7 +300,7 @@ public class Groups
             else
             {
                 throw new PKSyntaxError(
-                    "This group does not have an icon set. Set one by attaching an image to this command, or by passing an image URL or @mention.");
+                    "This group does not have an avatar set. Set one by attaching an image to this command, or by passing an image URL or @mention.");
             }
         }
 
@@ -364,7 +364,7 @@ public class Groups
             else
             {
                 throw new PKSyntaxError(
-                    "This group does not have a banner image set. Set one by attaching an image to this command, or by passing an image URL or @mention.");
+                    "This group does not have a banner image set. Set one by attaching an image to this command, or by passing an image URL.");
             }
         }
 


### PR DESCRIPTION
2 changes:

1) Correcting the use of 'icon' to 'avatar' to be consistent with `pk;member`.

2) Ditto as #603 but for groups.