### PR TITLE
Fix: avoid 403 status codes on image upload

### DIFF
--- a/PluralKit.Bot/CommandSystem/Context/ContextAvatarExt.cs
+++ b/PluralKit.Bot/CommandSystem/Context/ContextAvatarExt.cs
@@ -52,7 +52,7 @@ public static class ContextAvatarExt
 public struct ParsedImage
 {
     public string Url;
-    public string CleanUrl;
+    public string? CleanUrl;
     public AvatarSource Source;
     public User? SourceUser;
 }

--- a/PluralKit.Bot/CommandSystem/Context/ContextAvatarExt.cs
+++ b/PluralKit.Bot/CommandSystem/Context/ContextAvatarExt.cs
@@ -33,11 +33,14 @@ public static class ContextAvatarExt
         // If we have an attachment, use that
         if (ctx.Message.Attachments.FirstOrDefault() is { } attachment)
         {
-            // XXX: strip query params from attachment URLs because of new Discord CDN shenanigans
+            // XXX: discord attachment URLs are unable to be validated without their query params
+            // keep both the URL with query (for validation) and the clean URL (for storage) around
             var uriBuilder = new UriBuilder(attachment.ProxyUrl);
-            uriBuilder.Query = "";
 
-            return new ParsedImage { Url = uriBuilder.Uri.AbsoluteUri, Source = AvatarSource.Attachment };
+            ParsedImage img = new ParsedImage { Url = uriBuilder.Uri.AbsoluteUri, Source = AvatarSource.Attachment };
+            uriBuilder.Query = "";
+            img.CleanUrl = uriBuilder.Uri.AbsoluteUri;
+            return img;
         }
 
         // We should only get here if there are no arguments (which would get parsed as URL + throw if error)
@@ -49,6 +52,7 @@ public static class ContextAvatarExt
 public struct ParsedImage
 {
     public string Url;
+    public string CleanUrl;
     public AvatarSource Source;
     public User? SourceUser;
 }

--- a/PluralKit.Bot/Commands/Groups.cs
+++ b/PluralKit.Bot/Commands/Groups.cs
@@ -263,7 +263,7 @@ public class Groups
 
             await AvatarUtils.VerifyAvatarOrThrow(_client, img.Url);
 
-            await ctx.Repository.UpdateGroup(target.Id, new GroupPatch { Icon = img.Url });
+            await ctx.Repository.UpdateGroup(target.Id, new GroupPatch { Icon = img.CleanUrl });
 
             var msg = img.Source switch
             {
@@ -328,7 +328,7 @@ public class Groups
 
             await AvatarUtils.VerifyAvatarOrThrow(_client, img.Url, true);
 
-            await ctx.Repository.UpdateGroup(target.Id, new GroupPatch { BannerImage = img.Url });
+            await ctx.Repository.UpdateGroup(target.Id, new GroupPatch { BannerImage = img.CleanUrl });
 
             var msg = img.Source switch
             {

--- a/PluralKit.Bot/Commands/Groups.cs
+++ b/PluralKit.Bot/Commands/Groups.cs
@@ -263,7 +263,7 @@ public class Groups
 
             await AvatarUtils.VerifyAvatarOrThrow(_client, img.Url);
 
-            await ctx.Repository.UpdateGroup(target.Id, new GroupPatch { Icon = img.CleanUrl });
+            await ctx.Repository.UpdateGroup(target.Id, new GroupPatch { Icon = img.CleanUrl ?? img.Url });
 
             var msg = img.Source switch
             {
@@ -328,7 +328,7 @@ public class Groups
 
             await AvatarUtils.VerifyAvatarOrThrow(_client, img.Url, true);
 
-            await ctx.Repository.UpdateGroup(target.Id, new GroupPatch { BannerImage = img.CleanUrl });
+            await ctx.Repository.UpdateGroup(target.Id, new GroupPatch { BannerImage = img.CleanUrl ?? img.Url });
 
             var msg = img.Source switch
             {

--- a/PluralKit.Bot/Commands/Member.cs
+++ b/PluralKit.Bot/Commands/Member.cs
@@ -79,7 +79,7 @@ public class Member
                 img.CleanUrl = uriBuilder.Uri.AbsoluteUri;
 
                 await AvatarUtils.VerifyAvatarOrThrow(_client, img.Url);
-                await ctx.Repository.UpdateMember(member.Id, new MemberPatch { AvatarUrl = img.CleanUrl }, conn);
+                await ctx.Repository.UpdateMember(member.Id, new MemberPatch { AvatarUrl = img.CleanUrl ?? img.Url }, conn);
 
                 dispatchData.Add("avatar_url", img.CleanUrl);
             }

--- a/PluralKit.Bot/Commands/MemberAvatar.cs
+++ b/PluralKit.Bot/Commands/MemberAvatar.cs
@@ -3,6 +3,7 @@ using Myriad.Builders;
 using Myriad.Types;
 
 using PluralKit.Core;
+using Serilog;
 
 namespace PluralKit.Bot;
 
@@ -139,7 +140,7 @@ public class MemberAvatar
 
         ctx.CheckSystem().CheckOwnMember(target);
         await AvatarUtils.VerifyAvatarOrThrow(_client, avatarArg.Value.Url);
-        await UpdateAvatar(location, ctx, target, avatarArg.Value.Url);
+        await UpdateAvatar(location, ctx, target, avatarArg.Value.CleanUrl);
         await PrintResponse(location, ctx, target, avatarArg.Value, guildData);
     }
 

--- a/PluralKit.Bot/Commands/MemberAvatar.cs
+++ b/PluralKit.Bot/Commands/MemberAvatar.cs
@@ -3,7 +3,6 @@ using Myriad.Builders;
 using Myriad.Types;
 
 using PluralKit.Core;
-using Serilog;
 
 namespace PluralKit.Bot;
 

--- a/PluralKit.Bot/Commands/MemberAvatar.cs
+++ b/PluralKit.Bot/Commands/MemberAvatar.cs
@@ -139,7 +139,7 @@ public class MemberAvatar
 
         ctx.CheckSystem().CheckOwnMember(target);
         await AvatarUtils.VerifyAvatarOrThrow(_client, avatarArg.Value.Url);
-        await UpdateAvatar(location, ctx, target, avatarArg.Value.CleanUrl);
+        await UpdateAvatar(location, ctx, target, avatarArg.Value.CleanUrl ?? avatarArg.Value.Url);
         await PrintResponse(location, ctx, target, avatarArg.Value, guildData);
     }
 

--- a/PluralKit.Bot/Commands/MemberEdit.cs
+++ b/PluralKit.Bot/Commands/MemberEdit.cs
@@ -182,7 +182,7 @@ public class MemberEdit
         {
             await AvatarUtils.VerifyAvatarOrThrow(_client, img.Url, true);
 
-            await ctx.Repository.UpdateMember(target.Id, new MemberPatch { BannerImage = img.CleanUrl });
+            await ctx.Repository.UpdateMember(target.Id, new MemberPatch { BannerImage = img.CleanUrl ?? img.Url });
 
             var msg = img.Source switch
             {

--- a/PluralKit.Bot/Commands/MemberEdit.cs
+++ b/PluralKit.Bot/Commands/MemberEdit.cs
@@ -182,7 +182,7 @@ public class MemberEdit
         {
             await AvatarUtils.VerifyAvatarOrThrow(_client, img.Url, true);
 
-            await ctx.Repository.UpdateMember(target.Id, new MemberPatch { BannerImage = img.Url });
+            await ctx.Repository.UpdateMember(target.Id, new MemberPatch { BannerImage = img.CleanUrl });
 
             var msg = img.Source switch
             {

--- a/PluralKit.Bot/Commands/SystemEdit.cs
+++ b/PluralKit.Bot/Commands/SystemEdit.cs
@@ -475,7 +475,7 @@ public class SystemEdit
 
             await AvatarUtils.VerifyAvatarOrThrow(_client, img.Url);
 
-            await ctx.Repository.UpdateSystem(target.Id, new SystemPatch { AvatarUrl = img.CleanUrl });
+            await ctx.Repository.UpdateSystem(target.Id, new SystemPatch { AvatarUrl = img.CleanUrl ?? img.Url });
 
             var msg = img.Source switch
             {
@@ -543,7 +543,7 @@ public class SystemEdit
 
             await AvatarUtils.VerifyAvatarOrThrow(_client, img.Url);
 
-            await ctx.Repository.UpdateSystemGuild(target.Id, ctx.Guild.Id, new SystemGuildPatch { AvatarUrl = img.CleanUrl });
+            await ctx.Repository.UpdateSystemGuild(target.Id, ctx.Guild.Id, new SystemGuildPatch { AvatarUrl = img.CleanUrl ?? img.Url });
 
             var msg = img.Source switch
             {
@@ -640,7 +640,7 @@ public class SystemEdit
         {
             await AvatarUtils.VerifyAvatarOrThrow(_client, img.Url, true);
 
-            await ctx.Repository.UpdateSystem(target.Id, new SystemPatch { BannerImage = img.CleanUrl });
+            await ctx.Repository.UpdateSystem(target.Id, new SystemPatch { BannerImage = img.CleanUrl ?? img.Url });
 
             var msg = img.Source switch
             {

--- a/PluralKit.Bot/Commands/SystemEdit.cs
+++ b/PluralKit.Bot/Commands/SystemEdit.cs
@@ -475,7 +475,7 @@ public class SystemEdit
 
             await AvatarUtils.VerifyAvatarOrThrow(_client, img.Url);
 
-            await ctx.Repository.UpdateSystem(target.Id, new SystemPatch { AvatarUrl = img.Url });
+            await ctx.Repository.UpdateSystem(target.Id, new SystemPatch { AvatarUrl = img.CleanUrl });
 
             var msg = img.Source switch
             {
@@ -543,7 +543,7 @@ public class SystemEdit
 
             await AvatarUtils.VerifyAvatarOrThrow(_client, img.Url);
 
-            await ctx.Repository.UpdateSystemGuild(target.Id, ctx.Guild.Id, new SystemGuildPatch { AvatarUrl = img.Url });
+            await ctx.Repository.UpdateSystemGuild(target.Id, ctx.Guild.Id, new SystemGuildPatch { AvatarUrl = img.CleanUrl });
 
             var msg = img.Source switch
             {
@@ -640,7 +640,7 @@ public class SystemEdit
         {
             await AvatarUtils.VerifyAvatarOrThrow(_client, img.Url, true);
 
-            await ctx.Repository.UpdateSystem(target.Id, new SystemPatch { BannerImage = img.Url });
+            await ctx.Repository.UpdateSystem(target.Id, new SystemPatch { BannerImage = img.CleanUrl });
 
             var msg = img.Source switch
             {

--- a/PluralKit.Bot/Utils/AvatarUtils.cs
+++ b/PluralKit.Bot/Utils/AvatarUtils.cs
@@ -26,7 +26,6 @@ public static class AvatarUtils
             throw new PKError("Due to server issues, PluralKit is unable to read images hosted on toyhou.se.");
 
         url = TryRewriteCdnUrl(url);
-        Console.WriteLine(url);
 
         var response = await client.GetAsync(url);
         if (!response.IsSuccessStatusCode) // Check status code

--- a/PluralKit.Bot/Utils/AvatarUtils.cs
+++ b/PluralKit.Bot/Utils/AvatarUtils.cs
@@ -66,7 +66,7 @@ public static class AvatarUtils
         new(@"^https?://(?:cdn\.discordapp\.com|media\.discordapp\.net)/attachments/(\d{17,19})/(\d{17,19})/([^/\\&\?]+)\.(png|jpg|jpeg|webp)(\?.*)?$");
 
     private static readonly string DiscordMediaUrlReplacement =
-        "https://media.discordapp.net/attachments/$1/$2/$3.$4?width=256&height=256";
+        "https://media.discordapp.net/attachments/$1/$2/$3.$4$5width=256&height=256";
 
     public static string? TryRewriteCdnUrl(string? url) =>
         url == null ? null : DiscordCdnUrl.Replace(url, DiscordMediaUrlReplacement);

--- a/PluralKit.Bot/Utils/AvatarUtils.cs
+++ b/PluralKit.Bot/Utils/AvatarUtils.cs
@@ -78,7 +78,7 @@ public static class AvatarUtils
     {
         if (url == null)
             return null;
-        
+
         var match = DiscordCdnUrl.Match(url);
         var query = match.Groups["query"].Success;
 

--- a/PluralKit.Bot/Utils/AvatarUtils.cs
+++ b/PluralKit.Bot/Utils/AvatarUtils.cs
@@ -63,15 +63,10 @@ public static class AvatarUtils
     // This lets us add resizing parameters to "borrow" their media proxy server to downsize the image
     // which in turn makes it more likely to be underneath the size limit!
     private static readonly Regex DiscordCdnUrl =
-        new(@"^https?://(?:cdn\.discordapp\.com|media\.discordapp\.net)/attachments/(\d{17,19})/(\d{17,19})/([^/\\&\?]+)\.(png|jpg|jpeg|webp)(?<query>\?.*)?$");
+        new(@"^https?://(?:cdn\.discordapp\.com|media\.discordapp\.net)/attachments/(\d{17,19})/(\d{17,19})/([^/\\&\?]+)\.(png|jpg|jpeg|webp)(?:\?(?<query>.*))?$");
 
-    private static string DiscordMediaUrlReplacement(bool query = false)
-    {
-        var regexp = "https://media.discordapp.net/attachments/$1/$2/$3.$4";
-        regexp += query ? "$5" : "?";
-        regexp += "width=256&height=256";
-        return regexp;
-    }
+    private static readonly string DiscordMediaUrlReplacement =
+        "https://media.discordapp.net/attachments/$1/$2/$3.$4?width=256&height=256";
 
     public static string? TryRewriteCdnUrl(string? url)
     {
@@ -79,8 +74,10 @@ public static class AvatarUtils
             return null;
 
         var match = DiscordCdnUrl.Match(url);
-        var query = match.Groups["query"].Success;
+        var newUrl = DiscordCdnUrl.Replace(url, DiscordMediaUrlReplacement);
+        if (match.Groups["query"].Success)
+            newUrl += "&" + match.Groups["query"].Value;
 
-        return DiscordCdnUrl.Replace(url, DiscordMediaUrlReplacement(query));
+        return newUrl;
     }
 }


### PR DESCRIPTION
Avatar/banner uploads to discord now fetch with their query params included, which avoids those 403 status codes that we've been plagued with the past day.

(Even though they just seemed to have fixed themselves, can't hurt to be prepared for an inevitable future breakage)

Attachment URLs in the db are stored without these query params.