### PR TITLE
fix(api): refactor autoproxy controller so unlatching can work

### DIFF
--- a/PluralKit.API/Controllers/v2/AutoproxyControllerV2.cs
+++ b/PluralKit.API/Controllers/v2/AutoproxyControllerV2.cs
@@ -69,19 +69,25 @@ public class AutoproxyControllerV2: PKControllerBase
         var newAutoproxyMode = patch.AutoproxyMode.IsPresent ? patch.AutoproxyMode : oldData.AutoproxyMode;
         var newAutoproxyMember = patch.AutoproxyMember.IsPresent ? patch.AutoproxyMember : oldData.AutoproxyMember;
 
-        if (updateMember && member == null) {
+        if (updateMember && member == null)
+        {
             patch.Errors.Add(new("autoproxy_member", "Member not found."));
         }
 
-        if (newAutoproxyMode.Value == AutoproxyMode.Member) {
-            if (!updateMember) {
+        if (newAutoproxyMode.Value == AutoproxyMode.Member)
+        {
+            if (!updateMember)
+            {
                 patch.Errors.Add(new("autoproxy_member", "An autoproxy member must be supplied for autoproxy mode 'member'"));
             }
 
             patch.AutoproxyMode = newAutoproxyMode;
             patch.AutoproxyMember = newAutoproxyMember;
-        } else {
-            if (updateMember) {
+        }
+        else
+        {
+            if (updateMember)
+            {
                 patch.Errors.Add(new("autoproxy_member", "Cannot update autoproxy member if autoproxy mode is not set to 'member'"));
             }
 

--- a/PluralKit.API/Controllers/v2/AutoproxyControllerV2.cs
+++ b/PluralKit.API/Controllers/v2/AutoproxyControllerV2.cs
@@ -53,7 +53,7 @@ public class AutoproxyControllerV2: PKControllerBase
 
     private async Task<IActionResult> Patch(PKSystem system, ulong? guildId, ulong? channelId, JObject data, AutoproxySettings oldData)
     {
-        var updateMember = data.ContainsKey("autoproxy_member");
+        var updateMember = data.ContainsKey("autoproxy_member") && data.Value<string>("autoproxy_member") != null;
 
         PKMember? member = null;
         if (updateMember)
@@ -64,15 +64,31 @@ public class AutoproxyControllerV2: PKControllerBase
         }
 
         var patch = AutoproxyPatch.FromJson(data, member?.Id);
-
         patch.AssertIsValid();
-        if (updateMember && member == null)
+
+        var newAutoproxyMode = patch.AutoproxyMode.IsPresent ? patch.AutoproxyMode : oldData.AutoproxyMode;
+        var newAutoproxyMember = patch.AutoproxyMember.IsPresent ? patch.AutoproxyMember : oldData.AutoproxyMember;
+
+        if (updateMember && member == null) {
             patch.Errors.Add(new("autoproxy_member", "Member not found."));
-        if (updateMember && !(
-               (patch.AutoproxyMode.IsPresent && patch.AutoproxyMode.Value == AutoproxyMode.Member)
-            || (!patch.AutoproxyMode.IsPresent && oldData.AutoproxyMode == AutoproxyMode.Member))
-        )
-            patch.Errors.Add(new("autoproxy_member", "Cannot update autoproxy member if autoproxy mode is set to latch"));
+        }
+
+        if (newAutoproxyMode.Value == AutoproxyMode.Member) {
+            if (!updateMember) {
+                patch.Errors.Add(new("autoproxy_member", "An autoproxy member must be supplied for autoproxy mode 'member'"));
+            }
+
+            patch.AutoproxyMode = newAutoproxyMode;
+            patch.AutoproxyMember = newAutoproxyMember;
+        } else {
+            if (updateMember) {
+                patch.Errors.Add(new("autoproxy_member", "Cannot update autoproxy member if autoproxy mode is not set to 'member'"));
+            }
+
+            patch.AutoproxyMode = newAutoproxyMode;
+            patch.AutoproxyMember = null;
+        }
+
         if (patch.Errors.Count > 0)
             throw new ModelParseError(patch.Errors);
 


### PR DESCRIPTION
Follow-up to #599 after it was pointed out in the discord that this was supposed to already be possible with the current patch endpoint.
- Fixes the 500 error that was being caused then sending a patch of `{"autoproxy_member": null}` in latch mode - that now properly unlatches
- Clarifies the error handling around invalid states (setting it to mode `member` with no member specified and setting a member when the system's settings for that server is not in mode `member`)

I admittedly didn't *entirely* follow the way the logic was working before so while I believe this works the same (aside from the additional error case), and I have tested it and it appears working, I wouldn't be surprised if I missed something