### PR TITLE
Add shorthand 'pk;x' for 'pk;edit -regex'

### DIFF
--- a/PluralKit.Bot/CommandMeta/CommandTree.cs
+++ b/PluralKit.Bot/CommandMeta/CommandTree.cs
@@ -47,7 +47,9 @@ public partial class CommandTree
         if (ctx.Match("message", "msg"))
             return ctx.Execute<ProxiedMessage>(Message, m => m.GetMessage(ctx));
         if (ctx.Match("edit", "e"))
-            return ctx.Execute<ProxiedMessage>(MessageEdit, m => m.EditMessage(ctx));
+            return ctx.Execute<ProxiedMessage>(MessageEdit, m => m.EditMessage(ctx, false));
+        if (ctx.Match("x"))
+            return ctx.Execute<ProxiedMessage>(MessageEdit, m => m.EditMessage(ctx, true));
         if (ctx.Match("reproxy", "rp", "crimes"))
             return ctx.Execute<ProxiedMessage>(MessageReproxy, m => m.ReproxyMessage(ctx));
         if (ctx.Match("log"))

--- a/PluralKit.Bot/Commands/Message.cs
+++ b/PluralKit.Bot/Commands/Message.cs
@@ -91,7 +91,7 @@ public class ProxiedMessage
         }
     }
 
-    public async Task EditMessage(Context ctx)
+    public async Task EditMessage(Context ctx, bool useRegex)
     {
         var (msg, systemId) = await GetMessageToEdit(ctx, EditTimeout, false);
 
@@ -103,7 +103,7 @@ public class ProxiedMessage
             throw new PKError("Could not edit message.");
 
         // Regex flag
-        var useRegex = ctx.MatchFlag("regex", "x");
+        useRegex = useRegex || ctx.MatchFlag("regex", "x");
 
         // Check if we should append or prepend
         var mutateSpace = ctx.MatchFlag("nospace", "ns") ? "" : " ";

--- a/docs/content/tips-and-tricks.md
+++ b/docs/content/tips-and-tricks.md
@@ -27,6 +27,8 @@ PluralKit has a couple of useful command shorthands to reduce the typing:
 |pk;switch|pk;sw|
 |pk;message|pk;msg|
 |pk;autoproxy|pk;ap|
+|pk;edit|pk;e|
+|pk;edit -regex|pk;x|
 
 ## Member list flags
 There are a number of option flags that can be added to the `pk;system list` command.


### PR DESCRIPTION
Also adds entries for `pk;e` and `pk;x` in the command shorthands section of the Tips and Tricks.