### PR TITLE
fix(bot): don't parse member-exclusive list options for groups

### DIFF
--- a/PluralKit.Bot/Commands/GroupMember.cs
+++ b/PluralKit.Bot/Commands/GroupMember.cs
@@ -127,7 +127,7 @@ public class GroupMember
         var targetSystem = await GetGroupSystem(ctx, target);
         ctx.CheckSystemPrivacy(targetSystem.Id, target.ListPrivacy);
 
-        var opts = ctx.ParseListOptions(ctx.DirectLookupContextFor(target.System));
+        var opts = ctx.ParseListOptionsMember(ctx.DirectLookupContextFor(target.System));
         opts.GroupFilter = target.Id;
 
         var title = new StringBuilder($"Members of {target.DisplayName ?? target.Name} (`{target.Hid}`) in ");

--- a/PluralKit.Bot/Commands/Groups.cs
+++ b/PluralKit.Bot/Commands/Groups.cs
@@ -443,10 +443,10 @@ public class Groups
         ctx.CheckSystemPrivacy(system.Id, system.GroupListPrivacy);
 
         // explanation of privacy lookup here:
-        // - ParseListOptions checks list access privacy and sets the privacy filter (which members show up in list)
+        // - ParseListOptionsGroup checks list access privacy and sets the privacy filter (which members show up in list)
         // - RenderGroupList checks the indivual privacy for each member (NameFor, etc)
         // the own system is always allowed to look up their list
-        var opts = ctx.ParseListOptions(ctx.DirectLookupContextFor(system.Id));
+        var opts = ctx.ParseListOptionsGroup(ctx.DirectLookupContextFor(system.Id));
         await ctx.RenderGroupList(
             ctx.LookupContextFor(system.Id),
             system.Id,

--- a/PluralKit.Bot/Commands/Lists/ContextListExt.cs
+++ b/PluralKit.Bot/Commands/Lists/ContextListExt.cs
@@ -11,7 +11,7 @@ namespace PluralKit.Bot;
 
 public static class ContextListExt
 {
-    public static ListOptions ParseListOptions(this Context ctx, LookupContext lookupCtx)
+    private static ListOptions ParseListOptions(this Context ctx, LookupContext lookupCtx)
     {
         var p = new ListOptions();
 

--- a/PluralKit.Bot/Commands/Lists/ContextListExt.cs
+++ b/PluralKit.Bot/Commands/Lists/ContextListExt.cs
@@ -38,12 +38,7 @@ public static class ContextListExt
         if (ctx.MatchFlag("by-name", "bn")) p.SortProperty = SortProperty.Name;
         if (ctx.MatchFlag("by-display-name", "bdn")) p.SortProperty = SortProperty.DisplayName;
         if (ctx.MatchFlag("by-id", "bid")) p.SortProperty = SortProperty.Hid;
-        if (ctx.MatchFlag("by-message-count", "bmc")) p.SortProperty = SortProperty.MessageCount;
         if (ctx.MatchFlag("by-created", "bc", "bcd")) p.SortProperty = SortProperty.CreationDate;
-        if (ctx.MatchFlag("by-last-fronted", "by-last-front", "by-last-switch", "blf", "bls"))
-            p.SortProperty = SortProperty.LastSwitch;
-        if (ctx.MatchFlag("by-last-message", "blm", "blp")) p.SortProperty = SortProperty.LastMessage;
-        if (ctx.MatchFlag("by-birthday", "by-birthdate", "bbd")) p.SortProperty = SortProperty.Birthdate;
         if (ctx.MatchFlag("random")) p.SortProperty = SortProperty.Random;
 
         // Sort reverse?
@@ -60,29 +55,54 @@ public static class ContextListExt
             throw Errors.NotOwnInfo;
 
         // Additional fields to include in the search results
+        if (ctx.MatchFlag("with-created", "wc"))
+            p.IncludeCreated = true;
+        if (ctx.MatchFlag("with-avatar", "with-image", "with-icon", "wa", "wi", "ia", "ii", "img"))
+            p.IncludeAvatar = true;
+        if (ctx.MatchFlag("with-displayname", "wdn"))
+            p.IncludeDisplayName = true;
+
+        // Always show the sort property, too (unless this is the short list and we are already showing something else)
+        if (p.Type != ListType.Short || p.includedCount == 0)
+        {
+            if (p.SortProperty == SortProperty.DisplayName) p.IncludeDisplayName = true;
+            if (p.SortProperty == SortProperty.CreationDate) p.IncludeCreated = true;
+        }
+
+        // Make sure the options are valid
+        p.AssertIsValid();
+
+        // Done!
+        return p;
+    }
+
+    public static ListOptions ParseListOptionsMember(this Context ctx, LookupContext lookupCtx)
+    {
+        var p = ctx.ParseListOptions(lookupCtx);
+
+        // Sort property (default is by name, but adding a flag anyway, 'cause why not)
+        if (ctx.MatchFlag("by-message-count", "bmc")) p.SortProperty = SortProperty.MessageCount;
+        if (ctx.MatchFlag("by-last-fronted", "by-last-front", "by-last-switch", "blf", "bls"))
+            p.SortProperty = SortProperty.LastSwitch;
+        if (ctx.MatchFlag("by-last-message", "blm", "blp")) p.SortProperty = SortProperty.LastMessage;
+        if (ctx.MatchFlag("by-birthday", "by-birthdate", "bbd")) p.SortProperty = SortProperty.Birthdate;
+
+        // Additional fields to include in the search results
         if (ctx.MatchFlag("with-last-switch", "with-last-fronted", "with-last-front", "wls", "wlf"))
             p.IncludeLastSwitch = true;
         if (ctx.MatchFlag("with-last-message", "with-last-proxy", "wlm", "wlp"))
             p.IncludeLastMessage = true;
         if (ctx.MatchFlag("with-message-count", "wmc"))
             p.IncludeMessageCount = true;
-        if (ctx.MatchFlag("with-created", "wc"))
-            p.IncludeCreated = true;
-        if (ctx.MatchFlag("with-avatar", "with-image", "with-icon", "wa", "wi", "ia", "ii", "img"))
-            p.IncludeAvatar = true;
         if (ctx.MatchFlag("with-pronouns", "wp", "wprns"))
             p.IncludePronouns = true;
-        if (ctx.MatchFlag("with-displayname", "wdn"))
-            p.IncludeDisplayName = true;
         if (ctx.MatchFlag("with-birthday", "wbd", "wb"))
             p.IncludeBirthday = true;
 
         // Always show the sort property, too (unless this is the short list and we are already showing something else)
         if (p.Type != ListType.Short || p.includedCount == 0)
         {
-            if (p.SortProperty == SortProperty.DisplayName) p.IncludeDisplayName = true;
             if (p.SortProperty == SortProperty.MessageCount) p.IncludeMessageCount = true;
-            if (p.SortProperty == SortProperty.CreationDate) p.IncludeCreated = true;
             if (p.SortProperty == SortProperty.LastSwitch) p.IncludeLastSwitch = true;
             if (p.SortProperty == SortProperty.LastMessage) p.IncludeLastMessage = true;
             if (p.SortProperty == SortProperty.Birthdate) p.IncludeBirthday = true;
@@ -93,6 +113,11 @@ public static class ContextListExt
 
         // Done!
         return p;
+    }
+
+    public static ListOptions ParseListOptionsGroup(this Context ctx, LookupContext lookupCtx)
+    {
+        return ctx.ParseListOptions(lookupCtx);
     }
 
     public static async Task RenderMemberList(this Context ctx, LookupContext lookupCtx,

--- a/PluralKit.Bot/Commands/Lists/ContextListExt.cs
+++ b/PluralKit.Bot/Commands/Lists/ContextListExt.cs
@@ -69,10 +69,6 @@ public static class ContextListExt
             if (p.SortProperty == SortProperty.CreationDate) p.IncludeCreated = true;
         }
 
-        // Make sure the options are valid
-        p.AssertIsValid();
-
-        // Done!
         return p;
     }
 
@@ -117,7 +113,13 @@ public static class ContextListExt
 
     public static ListOptions ParseListOptionsGroup(this Context ctx, LookupContext lookupCtx)
     {
-        return ctx.ParseListOptions(lookupCtx);
+        var p = ctx.ParseListOptions(lookupCtx);
+
+        // Make sure the options are valid
+        p.AssertIsValid();
+
+        // Done!
+        return p;
     }
 
     public static async Task RenderMemberList(this Context ctx, LookupContext lookupCtx,

--- a/PluralKit.Bot/Commands/Random.cs
+++ b/PluralKit.Bot/Commands/Random.cs
@@ -67,7 +67,7 @@ public class Random
     {
         ctx.CheckSystemPrivacy(group.System, group.ListPrivacy);
 
-        var opts = ctx.ParseListOptions(ctx.DirectLookupContextFor(group.System));
+        var opts = ctx.ParseListOptionsMember(ctx.DirectLookupContextFor(group.System));
         opts.GroupFilter = group.Id;
 
         var members = await ctx.Database.Execute(conn => conn.QueryMemberList(group.System, opts.ToQueryOptions()));

--- a/PluralKit.Bot/Commands/SystemList.cs
+++ b/PluralKit.Bot/Commands/SystemList.cs
@@ -14,10 +14,10 @@ public class SystemList
         ctx.CheckSystemPrivacy(target.Id, target.MemberListPrivacy);
 
         // explanation of privacy lookup here:
-        // - ParseListOptions checks list access privacy and sets the privacy filter (which members show up in list)
+        // - ParseListOptionsMember checks list access privacy and sets the privacy filter (which members show up in list)
         // - RenderMemberList checks the indivual privacy for each member (NameFor, etc)
         // the own system is always allowed to look up their list
-        var opts = ctx.ParseListOptions(ctx.DirectLookupContextFor(target.Id));
+        var opts = ctx.ParseListOptionsMember(ctx.DirectLookupContextFor(target.Id));
         await ctx.RenderMemberList(
             ctx.LookupContextFor(target.Id),
             target.Id,


### PR DESCRIPTION
As reported in the Discord, using inapplicable options such as `-bmc`/`--by-message-count` when listing groups causes an error. This patch separates member and group list option parsing, fixing the source of the error and making room for the desired "`--by-member-count`" behavior to be added later.