### PR TITLE
tweak: use global list formatting for member group lists

### DIFF
--- a/PluralKit.Bot/Commands/GroupMember.cs
+++ b/PluralKit.Bot/Commands/GroupMember.cs
@@ -57,23 +57,23 @@ public class GroupMember
         var opts = ctx.ParseListOptions(ctx.DirectLookupContextFor(target.System));
         opts.MemberFilter = target.Id;
 
-        var title = new StringBuilder($"Groups containing {target.Name} (`{target.Hid}`) in ");
+        var title = new StringBuilder($"Groups containing {target.Name} (`{target.DisplayHid(ctx.Config)}`) in ");
         if (ctx.Guild != null)
         {
             var guildSettings = await ctx.Repository.GetSystemGuild(ctx.Guild.Id, targetSystem.Id);
             if (guildSettings.DisplayName != null)
-                title.Append($"{guildSettings.DisplayName} (`{targetSystem.Hid}`)");
+                title.Append($"{guildSettings.DisplayName} (`{targetSystem.DisplayHid(ctx.Config)}`)");
             else if (targetSystem.NameFor(ctx) != null)
-                title.Append($"{targetSystem.NameFor(ctx)} (`{targetSystem.Hid}`)");
+                title.Append($"{targetSystem.NameFor(ctx)} (`{targetSystem.DisplayHid(ctx.Config)}`)");
             else
-                title.Append($"`{targetSystem.Hid}`");
+                title.Append($"`{targetSystem.DisplayHid(ctx.Config)}`");
         }
         else
         {
             if (targetSystem.NameFor(ctx) != null)
-                title.Append($"{targetSystem.NameFor(ctx)} (`{targetSystem.Hid}`)");
+                title.Append($"{targetSystem.NameFor(ctx)} (`{targetSystem.DisplayHid(ctx.Config)}`)");
             else
-                title.Append($"`{targetSystem.Hid}`");
+                title.Append($"`{targetSystem.DisplayHid(ctx.Config)}`");
         }
         if (opts.Search != null)
             title.Append($" matching **{opts.Search.Truncate(100)}**");

--- a/PluralKit.Bot/Commands/GroupMember.cs
+++ b/PluralKit.Bot/Commands/GroupMember.cs
@@ -53,31 +53,33 @@ public class GroupMember
 
     public async Task ListMemberGroups(Context ctx, PKMember target)
     {
-        var pctx = ctx.DirectLookupContextFor(target.System);
+        var targetSystem = await ctx.Repository.GetSystem(target.System);
+        var opts = ctx.ParseListOptions(ctx.DirectLookupContextFor(target.System));
+        opts.MemberFilter = target.Id;
 
-        var groups = await ctx.Repository.GetMemberGroups(target.Id)
-            .Where(g => g.Visibility.CanAccess(pctx))
-            .OrderBy(g => (g.DisplayName ?? g.Name), StringComparer.InvariantCultureIgnoreCase)
-            .ToListAsync();
-
-        var description = "";
-        var msg = "";
-
-        if (groups.Count == 0)
-            description = "This member has no groups.";
-        else
-            description = string.Join("\n", groups.Select(g => $"[`{g.DisplayHid(ctx.Config, isList: true)}`] **{g.DisplayName ?? g.Name}**"));
-
-        if (pctx == LookupContext.ByOwner)
+        var title = new StringBuilder($"Groups containing {target.Name} (`{target.Hid}`) in ");
+        if (ctx.Guild != null)
         {
-            msg +=
-                $"\n\nTo add this member to one or more groups, use `pk;m {target.Reference(ctx)} group add <group> [group 2] [group 3...]`";
-            if (groups.Count > 0)
-                msg +=
-                    $"\nTo remove this member from one or more groups, use `pk;m {target.Reference(ctx)} group remove <group> [group 2] [group 3...]`";
+            var guildSettings = await ctx.Repository.GetSystemGuild(ctx.Guild.Id, targetSystem.Id);
+            if (guildSettings.DisplayName != null)
+                title.Append($"{guildSettings.DisplayName} (`{targetSystem.Hid}`)");
+            else if (targetSystem.NameFor(ctx) != null)
+                title.Append($"{targetSystem.NameFor(ctx)} (`{targetSystem.Hid}`)");
+            else
+                title.Append($"`{targetSystem.Hid}`");
         }
+        else
+        {
+            if (targetSystem.NameFor(ctx) != null)
+                title.Append($"{targetSystem.NameFor(ctx)} (`{targetSystem.Hid}`)");
+            else
+                title.Append($"`{targetSystem.Hid}`");
+        }
+        if (opts.Search != null)
+            title.Append($" matching **{opts.Search.Truncate(100)}**");
 
-        await ctx.Reply(msg, new EmbedBuilder().Title($"{target.Name}'s groups").Description(description).Build());
+        await ctx.RenderGroupList(ctx.LookupContextFor(target.System), target.System, title.ToString(),
+            target.Color, opts);
     }
 
     public async Task AddRemoveMembers(Context ctx, PKGroup target, Groups.AddRemoveOperation op)

--- a/PluralKit.Bot/Commands/Lists/ListOptions.cs
+++ b/PluralKit.Bot/Commands/Lists/ListOptions.cs
@@ -29,6 +29,7 @@ public class ListOptions
 
     public PrivacyLevel? PrivacyFilter { get; set; } = PrivacyLevel.Public;
     public GroupId? GroupFilter { get; set; }
+    public MemberId? MemberFilter { get; set; }
     public string? Search { get; set; }
     public bool SearchDescription { get; set; }
 
@@ -96,6 +97,7 @@ public class ListOptions
         {
             PrivacyFilter = PrivacyFilter,
             GroupFilter = GroupFilter,
+            MemberFilter = MemberFilter,
             Search = Search,
             SearchDescription = SearchDescription
         };

--- a/PluralKit.Core/Database/Views/DatabaseViewsExt.cs
+++ b/PluralKit.Core/Database/Views/DatabaseViewsExt.cs
@@ -10,7 +10,11 @@ public static class DatabaseViewsExt
     public static Task<IEnumerable<ListedGroup>> QueryGroupList(this IPKConnection conn, SystemId system,
                                                                   ListQueryOptions opts)
     {
-        StringBuilder query = new StringBuilder("select * from group_list where system = @system");
+        StringBuilder query;
+        if (opts.MemberFilter == null)
+            query = new StringBuilder("select * from group_list where system = @system");
+        else
+            query = new StringBuilder("select group_list.* from group_members inner join group_list on group_list.id = group_members.group_id where member_id = @MemberFilter");
 
         if (opts.PrivacyFilter != null)
             query.Append($" and visibility = {(int)opts.PrivacyFilter}");
@@ -36,7 +40,7 @@ public static class DatabaseViewsExt
 
         return conn.QueryAsync<ListedGroup>(
             query.ToString(),
-            new { system, filter = opts.Search });
+            new { system, filter = opts.Search, memberFilter = opts.MemberFilter });
     }
     public static Task<IEnumerable<ListedMember>> QueryMemberList(this IPKConnection conn, SystemId system,
                                                                   ListQueryOptions opts)
@@ -81,5 +85,6 @@ public static class DatabaseViewsExt
         public bool SearchDescription;
         public LookupContext Context;
         public GroupId? GroupFilter;
+        public MemberId? MemberFilter;
     }
 }


### PR DESCRIPTION
This PR replaces the old member group list formatting (that you could only get by doing `pk;m <name> groups`) with the more regular formatting used by all member lists and the system-wide group list.

I don't know how to explain it better, so here's some screenshots to demonstrate.

**Old formatting**
![image](https://github.com/PluralKit/PluralKit/assets/72747870/97cae838-93fd-4adc-b58f-48658ac42cba)

**New (more consistent) formatting**
![image](https://github.com/PluralKit/PluralKit/assets/72747870/4a216ea0-eb5e-4eee-9d0d-c6575a2987f0)


note that this PR doesn't fix the errors thrown by trying to sort/filter by a property that does not exist on groups, but does exist on members (i.e. `pk;m <name> groups -bmc` will still error)