### PR TITLE
6-character HID rework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ target/
 .idea/
 .run/
 .vscode/
+.mono/
 tags/
 .DS_Store
 mono_crash*

--- a/PluralKit.API/Controllers/PKControllerBase.cs
+++ b/PluralKit.API/Controllers/PKControllerBase.cs
@@ -9,7 +9,6 @@ namespace PluralKit.API;
 public class PKControllerBase: ControllerBase
 {
     private readonly Guid _requestId = Guid.NewGuid();
-    private readonly Regex _shortIdRegex = new("^[a-z]{5}$");
     private readonly Regex _snowflakeRegex = new("^[0-9]{17,19}$");
 
     private List<PKMember>? _memberLookupCache { get; set; }
@@ -46,8 +45,8 @@ public class PKControllerBase: ControllerBase
         if (_snowflakeRegex.IsMatch(systemRef))
             return _repo.GetSystemByAccount(ulong.Parse(systemRef));
 
-        if (_shortIdRegex.IsMatch(systemRef))
-            return _repo.GetSystemByHid(systemRef);
+        if (systemRef.TryParseHid(out var hid))
+            return _repo.GetSystemByHid(hid);
 
         return Task.FromResult<PKSystem?>(null);
     }
@@ -71,8 +70,8 @@ public class PKControllerBase: ControllerBase
         if (Guid.TryParse(memberRef, out var guid))
             return await _repo.GetMemberByGuid(guid);
 
-        if (_shortIdRegex.IsMatch(memberRef))
-            return await _repo.GetMemberByHid(memberRef);
+        if (memberRef.TryParseHid(out var hid))
+            return await _repo.GetMemberByHid(hid);
 
         return null;
     }
@@ -96,8 +95,8 @@ public class PKControllerBase: ControllerBase
         if (Guid.TryParse(groupRef, out var guid))
             return await _repo.GetGroupByGuid(guid);
 
-        if (_shortIdRegex.IsMatch(groupRef))
-            return await _repo.GetGroupByHid(groupRef);
+        if (groupRef.TryParseHid(out var hid))
+            return await _repo.GetGroupByHid(hid);
 
         return null;
     }

--- a/PluralKit.Bot/ApplicationCommands/Message.cs
+++ b/PluralKit.Bot/ApplicationCommands/Message.cs
@@ -48,11 +48,12 @@ public class ApplicationCommandProxiedMessage
                 msg.System,
                 msg.Member,
                 guild,
+                ctx.Config,
                 LookupContext.ByNonOwner,
                 DateTimeZone.Utc
             ));
 
-        embeds.Add(await _embeds.CreateMessageInfoEmbed(msg, showContent));
+        embeds.Add(await _embeds.CreateMessageInfoEmbed(msg, showContent, ctx.Config));
 
         await ctx.Reply(embeds: embeds.ToArray());
     }

--- a/PluralKit.Bot/CommandMeta/CommandTree.cs
+++ b/PluralKit.Bot/CommandMeta/CommandTree.cs
@@ -538,6 +538,8 @@ public partial class CommandTree
             return ctx.Execute<Config>(null, m => m.CaseSensitiveProxyTags(ctx));
         if (ctx.MatchMultiple(new[] { "proxy" }, new[] { "error" }) || ctx.Match("pe"))
             return ctx.Execute<Config>(null, m => m.ProxyErrorMessageEnabled(ctx));
+        if (ctx.MatchMultiple(new[] { "split" }, new[] { "ids" }) || ctx.Match("sid"))
+            return ctx.Execute<Config>(null, m => m.HidDisplaySplit(ctx));
 
         // todo: maybe add the list of configuration keys here?
         return ctx.Reply($"{Emojis.Error} Could not find a setting with that name. Please see `pk;commands config` for the list of possible config settings.");

--- a/PluralKit.Bot/CommandMeta/CommandTree.cs
+++ b/PluralKit.Bot/CommandMeta/CommandTree.cs
@@ -538,9 +538,9 @@ public partial class CommandTree
             return ctx.Execute<Config>(null, m => m.CaseSensitiveProxyTags(ctx));
         if (ctx.MatchMultiple(new[] { "proxy" }, new[] { "error" }) || ctx.Match("pe"))
             return ctx.Execute<Config>(null, m => m.ProxyErrorMessageEnabled(ctx));
-        if (ctx.MatchMultiple(new[] { "split" }, new[] { "id", "ids" }) || ctx.Match("sid"))
+        if (ctx.MatchMultiple(new[] { "split" }, new[] { "id", "ids" }) || ctx.Match("sid", "sids"))
             return ctx.Execute<Config>(null, m => m.HidDisplaySplit(ctx));
-        if (ctx.MatchMultiple(new[] { "caps", "capitalize", "capitalise" }, new[] { "id", "ids" }) || ctx.Match("capid"))
+        if (ctx.MatchMultiple(new[] { "cap", "caps", "capitalize", "capitalise" }, new[] { "id", "ids" }) || ctx.Match("capid", "capids"))
             return ctx.Execute<Config>(null, m => m.HidDisplayCaps(ctx));
 
         // todo: maybe add the list of configuration keys here?

--- a/PluralKit.Bot/CommandMeta/CommandTree.cs
+++ b/PluralKit.Bot/CommandMeta/CommandTree.cs
@@ -540,6 +540,8 @@ public partial class CommandTree
             return ctx.Execute<Config>(null, m => m.ProxyErrorMessageEnabled(ctx));
         if (ctx.MatchMultiple(new[] { "split" }, new[] { "id", "ids" }) || ctx.Match("sid"))
             return ctx.Execute<Config>(null, m => m.HidDisplaySplit(ctx));
+        if (ctx.MatchMultiple(new[] { "caps", "capitalize", "capitalise" }, new[] { "id", "ids" }) || ctx.Match("capid"))
+            return ctx.Execute<Config>(null, m => m.HidDisplayCaps(ctx));
 
         // todo: maybe add the list of configuration keys here?
         return ctx.Reply($"{Emojis.Error} Could not find a setting with that name. Please see `pk;commands config` for the list of possible config settings.");

--- a/PluralKit.Bot/CommandMeta/CommandTree.cs
+++ b/PluralKit.Bot/CommandMeta/CommandTree.cs
@@ -538,7 +538,7 @@ public partial class CommandTree
             return ctx.Execute<Config>(null, m => m.CaseSensitiveProxyTags(ctx));
         if (ctx.MatchMultiple(new[] { "proxy" }, new[] { "error" }) || ctx.Match("pe"))
             return ctx.Execute<Config>(null, m => m.ProxyErrorMessageEnabled(ctx));
-        if (ctx.MatchMultiple(new[] { "split" }, new[] { "ids" }) || ctx.Match("sid"))
+        if (ctx.MatchMultiple(new[] { "split" }, new[] { "id", "ids" }) || ctx.Match("sid"))
             return ctx.Execute<Config>(null, m => m.HidDisplaySplit(ctx));
 
         // todo: maybe add the list of configuration keys here?

--- a/PluralKit.Bot/CommandSystem/Context/ContextEntityArgumentsExt.cs
+++ b/PluralKit.Bot/CommandSystem/Context/ContextEntityArgumentsExt.cs
@@ -172,12 +172,12 @@ public static class ContextEntityArgumentsExt
 
         if (isIDOnlyQuery)
         {
-            if (input.Length == 5)
+            if (input.Length >= 5 && input.Length <= 6)
                 return $"{entity} with ID \"{input}\" not found.";
             return $"{entity} not found. Note that a {entity.ToLower()} ID is 5 or 6 characters long.";
         }
 
-        if (input.Length == 5)
+        if (input.Length >= 5 && input.Length <= 6)
             return $"{entity} with ID or name \"{input}\" not found.";
         return $"{entity} with name \"{input}\" not found. Note that a {entity.ToLower()} ID is 5 or 6 characters long.";
     }

--- a/PluralKit.Bot/CommandSystem/Context/ContextEntityArgumentsExt.cs
+++ b/PluralKit.Bot/CommandSystem/Context/ContextEntityArgumentsExt.cs
@@ -169,15 +169,16 @@ public static class ContextEntityArgumentsExt
     public static string CreateNotFoundError(this Context ctx, string entity, string input)
     {
         var isIDOnlyQuery = ctx.System == null || ctx.MatchFlag("id", "by-id");
+        var inputIsHid = HidUtils.ParseHid(input) != null;
 
         if (isIDOnlyQuery)
         {
-            if (input.Length >= 5 && input.Length <= 6)
+            if (inputIsHid)
                 return $"{entity} with ID \"{input}\" not found.";
             return $"{entity} not found. Note that a {entity.ToLower()} ID is 5 or 6 characters long.";
         }
 
-        if (input.Length >= 5 && input.Length <= 6)
+        if (inputIsHid)
             return $"{entity} with ID or name \"{input}\" not found.";
         return $"{entity} with name \"{input}\" not found. Note that a {entity.ToLower()} ID is 5 or 6 characters long.";
     }

--- a/PluralKit.Bot/Commands/Admin.cs
+++ b/PluralKit.Bot/Commands/Admin.cs
@@ -29,9 +29,9 @@ public class Admin
         if (target == null)
             throw new PKError("Unknown system.");
 
-        var newHid = ctx.PopArgument();
-        if (!Regex.IsMatch(newHid, "^[a-z]{5}$"))
-            throw new PKError($"Invalid new system ID `{newHid}`.");
+        var input = ctx.PopArgument();
+        if (!input.TryParseHid(out var newHid))
+            throw new PKError($"Invalid new system ID `{input}`.");
 
         var existingSystem = await ctx.Repository.GetSystemByHid(newHid);
         if (existingSystem != null)
@@ -52,9 +52,9 @@ public class Admin
         if (target == null)
             throw new PKError("Unknown member.");
 
-        var newHid = ctx.PopArgument();
-        if (!Regex.IsMatch(newHid, "^[a-z]{5}$"))
-            throw new PKError($"Invalid new member ID `{newHid}`.");
+        var input = ctx.PopArgument();
+        if (!input.TryParseHid(out var newHid))
+            throw new PKError($"Invalid new member ID `{input}`.");
 
         var existingMember = await ctx.Repository.GetMemberByHid(newHid);
         if (existingMember != null)
@@ -78,9 +78,9 @@ public class Admin
         if (target == null)
             throw new PKError("Unknown group.");
 
-        var newHid = ctx.PopArgument();
-        if (!Regex.IsMatch(newHid, "^[a-z]{5}$"))
-            throw new PKError($"Invalid new group ID `{newHid}`.");
+        var input = ctx.PopArgument();
+        if (!input.TryParseHid(out var newHid))
+            throw new PKError($"Invalid new group ID `{input}`.");
 
         var existingGroup = await ctx.Repository.GetGroupByHid(newHid);
         if (existingGroup != null)

--- a/PluralKit.Bot/Commands/Autoproxy.cs
+++ b/PluralKit.Bot/Commands/Autoproxy.cs
@@ -130,7 +130,7 @@ public class Autoproxy
                     {
                         if (relevantMember == null)
                             throw new ArgumentException("Attempted to print member autoproxy status, but the linked member ID wasn't found in the database. Should be handled appropriately.");
-                        eb.Description($"Autoproxy is currently set to **front mode** in this server. The current (first) fronter is **{relevantMember.NameFor(ctx).EscapeMarkdown()}** (`{relevantMember.Hid}`). To disable, type `pk;autoproxy off`.");
+                        eb.Description($"Autoproxy is currently set to **front mode** in this server. The current (first) fronter is **{relevantMember.NameFor(ctx).EscapeMarkdown()}** (`{relevantMember.DisplayHid(ctx.Config)}`). To disable, type `pk;autoproxy off`.");
                     }
 
                     break;
@@ -142,7 +142,7 @@ public class Autoproxy
                         // ideally we would set it to off in the database though...
                         eb.Description($"Autoproxy is currently **off** in this server. To enable it, use one of the following commands:\n{commandList}");
                     else
-                        eb.Description($"Autoproxy is active for member **{relevantMember.NameFor(ctx)}** (`{relevantMember.Hid}`) in this server. To disable, type `pk;autoproxy off`.");
+                        eb.Description($"Autoproxy is active for member **{relevantMember.NameFor(ctx)}** (`{relevantMember.DisplayHid(ctx.Config)}`) in this server. To disable, type `pk;autoproxy off`.");
 
                     break;
                 }
@@ -150,7 +150,7 @@ public class Autoproxy
                 if (relevantMember == null)
                     eb.Description("Autoproxy is currently set to **latch mode**, meaning the *last-proxied member* will be autoproxied. **No member is currently latched.** To disable, type `pk;autoproxy off`.");
                 else
-                    eb.Description($"Autoproxy is currently set to **latch mode**, meaning the *last-proxied member* will be autoproxied. The currently latched member is **{relevantMember.NameFor(ctx)}** (`{relevantMember.Hid}`). To disable, type `pk;autoproxy off`.");
+                    eb.Description($"Autoproxy is currently set to **latch mode**, meaning the *last-proxied member* will be autoproxied. The currently latched member is **{relevantMember.NameFor(ctx)}** (`{relevantMember.DisplayHid(ctx.Config)}`). To disable, type `pk;autoproxy off`.");
 
                 break;
 

--- a/PluralKit.Bot/Commands/Config.cs
+++ b/PluralKit.Bot/Commands/Config.cs
@@ -102,6 +102,13 @@ public class Config
             "enabled"
         ));
 
+        items.Add(new(
+            "Split IDs",
+            "Whether to display 6-character IDs split with a hyphen, to ease readability",
+            EnabledDisabled(ctx.Config.HidDisplaySplit),
+            "disabled"
+        ));
+
         await ctx.Paginate<PaginatedConfigItem>(
             items.ToAsyncEnumerable(),
             items.Count,
@@ -442,5 +449,19 @@ public class Config
 
             await ctx.Reply("Proxy error messages are now disabled. Messages that fail to proxy (due to message or attachment size) will not throw an error message.");
         }
+    }
+
+    public async Task HidDisplaySplit(Context ctx)
+    {
+        if (!ctx.HasNext())
+        {
+            var msg = $"Splitting of 6-character IDs with a hyphen is currently **{EnabledDisabled(ctx.Config.HidDisplaySplit)}**.";
+            await ctx.Reply(msg);
+            return;
+        }
+
+        var newVal = ctx.MatchToggle(true);
+        await ctx.Repository.UpdateSystemConfig(ctx.System.Id, new() { HidDisplaySplit = newVal });
+        await ctx.Reply($"Splitting of 6-character IDs with a hyphen is now {EnabledDisabled(newVal)}.");
     }
 }

--- a/PluralKit.Bot/Commands/Config.cs
+++ b/PluralKit.Bot/Commands/Config.cs
@@ -109,6 +109,13 @@ public class Config
             "disabled"
         ));
 
+        items.Add(new(
+            "Capitalize IDs",
+            "Whether to display IDs as capital letters, to ease readability",
+            EnabledDisabled(ctx.Config.HidDisplayCaps),
+            "disabled"
+        ));
+
         await ctx.Paginate<PaginatedConfigItem>(
             items.ToAsyncEnumerable(),
             items.Count,
@@ -463,5 +470,19 @@ public class Config
         var newVal = ctx.MatchToggle(true);
         await ctx.Repository.UpdateSystemConfig(ctx.System.Id, new() { HidDisplaySplit = newVal });
         await ctx.Reply($"Splitting of 6-character IDs with a hyphen is now {EnabledDisabled(newVal)}.");
+    }
+
+    public async Task HidDisplayCaps(Context ctx)
+    {
+        if (!ctx.HasNext())
+        {
+            var msg = $"Displaying IDs as capital letters is currently **{EnabledDisabled(ctx.Config.HidDisplayCaps)}**.";
+            await ctx.Reply(msg);
+            return;
+        }
+
+        var newVal = ctx.MatchToggle(true);
+        await ctx.Repository.UpdateSystemConfig(ctx.System.Id, new() { HidDisplayCaps = newVal });
+        await ctx.Reply($"Displaying IDs as capital letters is now {EnabledDisabled(newVal)}.");
     }
 }

--- a/PluralKit.Bot/Commands/GroupMember.cs
+++ b/PluralKit.Bot/Commands/GroupMember.cs
@@ -66,7 +66,7 @@ public class GroupMember
         if (groups.Count == 0)
             description = "This member has no groups.";
         else
-            description = string.Join("\n", groups.Select(g => $"[`{g.Hid}`] **{g.DisplayName ?? g.Name}**"));
+            description = string.Join("\n", groups.Select(g => $"[`{g.DisplayHid(ctx.Config)}`] **{g.DisplayName ?? g.Name}**"));
 
         if (pctx == LookupContext.ByOwner)
         {
@@ -130,23 +130,23 @@ public class GroupMember
         var opts = ctx.ParseListOptions(ctx.DirectLookupContextFor(target.System));
         opts.GroupFilter = target.Id;
 
-        var title = new StringBuilder($"Members of {target.DisplayName ?? target.Name} (`{target.Hid}`) in ");
+        var title = new StringBuilder($"Members of {target.DisplayName ?? target.Name} (`{target.DisplayHid(ctx.Config)}`) in ");
         if (ctx.Guild != null)
         {
             var guildSettings = await ctx.Repository.GetSystemGuild(ctx.Guild.Id, targetSystem.Id);
             if (guildSettings.DisplayName != null)
-                title.Append($"{guildSettings.DisplayName} (`{targetSystem.Hid}`)");
+                title.Append($"{guildSettings.DisplayName} (`{targetSystem.DisplayHid(ctx.Config)}`)");
             else if (targetSystem.NameFor(ctx) != null)
-                title.Append($"{targetSystem.NameFor(ctx)} (`{targetSystem.Hid}`)");
+                title.Append($"{targetSystem.NameFor(ctx)} (`{targetSystem.DisplayHid(ctx.Config)}`)");
             else
-                title.Append($"`{targetSystem.Hid}`");
+                title.Append($"`{targetSystem.DisplayHid(ctx.Config)}`");
         }
         else
         {
             if (targetSystem.NameFor(ctx) != null)
-                title.Append($"{targetSystem.NameFor(ctx)} (`{targetSystem.Hid}`)");
+                title.Append($"{targetSystem.NameFor(ctx)} (`{targetSystem.DisplayHid(ctx.Config)}`)");
             else
-                title.Append($"`{targetSystem.Hid}`");
+                title.Append($"`{targetSystem.DisplayHid(ctx.Config)}`");
         }
         if (opts.Search != null)
             title.Append($" matching **{opts.Search.Truncate(100)}**");

--- a/PluralKit.Bot/Commands/Groups.cs
+++ b/PluralKit.Bot/Commands/Groups.cs
@@ -53,7 +53,7 @@ public class Groups
         if (existingGroup != null)
         {
             var msg =
-                $"{Emojis.Warn} You already have a group in your system with the name \"{existingGroup.Name}\" (with ID `{existingGroup.Hid}`). Do you want to create another group with the same name?";
+                $"{Emojis.Warn} You already have a group in your system with the name \"{existingGroup.Name}\" (with ID `{existingGroup.DisplayHid(ctx.Config)}`). Do you want to create another group with the same name?";
             if (!await ctx.PromptYesNo(msg, "Create"))
                 throw new PKError("Group creation cancelled.");
         }
@@ -83,7 +83,7 @@ public class Groups
 
         var eb = new EmbedBuilder()
             .Description(
-                $"Your new group, **{groupName}**, has been created, with the group ID **`{newGroup.Hid}`**.\nBelow are a couple of useful commands:")
+                $"Your new group, **{groupName}**, has been created, with the group ID **`{newGroup.DisplayHid(ctx.Config)}`**.\nBelow are a couple of useful commands:")
             .Field(new Embed.Field("View the group card", $"> pk;group **{reference}**"))
             .Field(new Embed.Field("Add members to the group",
                 $"> pk;group **{reference}** add **MemberName**\n> pk;group **{reference}** add **Member1** **Member2** **Member3** (and so on...)"))
@@ -113,7 +113,7 @@ public class Groups
         if (existingGroup != null && existingGroup.Id != target.Id)
         {
             var msg =
-                $"{Emojis.Warn} You already have a group in your system with the name \"{existingGroup.Name}\" (with ID `{existingGroup.Hid}`). Do you want to rename this group to that name too?";
+                $"{Emojis.Warn} You already have a group in your system with the name \"{existingGroup.Name}\" (with ID `{existingGroup.DisplayHid(ctx.Config)}`). Do you want to rename this group to that name too?";
             if (!await ctx.PromptYesNo(msg, "Rename"))
                 throw new PKError("Group rename cancelled.");
         }
@@ -450,20 +450,20 @@ public class Groups
         await ctx.RenderGroupList(
             ctx.LookupContextFor(system.Id),
             system.Id,
-            GetEmbedTitle(system, opts),
+            GetEmbedTitle(ctx, system, opts),
             system.Color,
             opts
         );
     }
 
-    private string GetEmbedTitle(PKSystem target, ListOptions opts)
+    private string GetEmbedTitle(Context ctx, PKSystem target, ListOptions opts)
     {
         var title = new StringBuilder("Groups of ");
 
         if (target.Name != null)
-            title.Append($"{target.Name} (`{target.Hid}`)");
+            title.Append($"{target.Name} (`{target.DisplayHid(ctx.Config)}`)");
         else
-            title.Append($"`{target.Hid}`");
+            title.Append($"`{target.DisplayHid(ctx.Config)}`");
 
         if (opts.Search != null)
             title.Append($" matching **{opts.Search}**");
@@ -586,7 +586,7 @@ public class Groups
 
     public async Task DisplayId(Context ctx, PKGroup target)
     {
-        await ctx.Reply(target.Hid);
+        await ctx.Reply(target.DisplayHid(ctx.Config));
     }
 
     private async Task<PKSystem> GetGroupSystem(Context ctx, PKGroup target)

--- a/PluralKit.Bot/Commands/Groups.cs
+++ b/PluralKit.Bot/Commands/Groups.cs
@@ -574,10 +574,10 @@ public class Groups
         ctx.CheckOwnGroup(target);
 
         await ctx.Reply(
-            $"{Emojis.Warn} Are you sure you want to delete this group? If so, reply to this message with the group's ID (`{target.Hid}`).\n**Note: this action is permanent.**");
-        if (!await ctx.ConfirmWithReply(target.Hid))
+            $"{Emojis.Warn} Are you sure you want to delete this group? If so, reply to this message with the group's ID (`{target.DisplayHid(ctx.Config)}`).\n**Note: this action is permanent.**");
+        if (!await ctx.ConfirmWithReply(target.Hid, treatAsHid: true))
             throw new PKError(
-                $"Group deletion cancelled. Note that you must reply with your group ID (`{target.Hid}`) *verbatim*.");
+                $"Group deletion cancelled. Note that you must reply with your group ID (`{target.DisplayHid(ctx.Config)}`) *verbatim*.");
 
         await ctx.Repository.DeleteGroup(target.Id);
 

--- a/PluralKit.Bot/Commands/Lists/ContextListExt.cs
+++ b/PluralKit.Bot/Commands/Lists/ContextListExt.cs
@@ -128,7 +128,7 @@ public static class ContextListExt
             // so run it through a helper that "makes it work" :)
             eb.WithSimpleLineContent(page.Select(m =>
             {
-                var ret = $"[`{m.Hid}`] **{m.NameFor(ctx)}** ";
+                var ret = $"[`{m.DisplayHid(ctx.Config)}`] **{m.NameFor(ctx)}** ";
 
                 if (opts.IncludeMessageCount && m.MessageCountFor(lookupCtx) is { } count)
                     ret += $"({count} messages)";
@@ -162,7 +162,7 @@ public static class ContextListExt
         {
             foreach (var m in page)
             {
-                var profile = new StringBuilder($"**ID**: {m.Hid}");
+                var profile = new StringBuilder($"**ID**: {m.DisplayHid(ctx.Config)}");
 
                 if (m.DisplayName != null && m.NamePrivacy.CanAccess(lookupCtx))
                     profile.Append($"\n**Display name**: {m.DisplayName}");
@@ -238,7 +238,7 @@ public static class ContextListExt
             // so run it through a helper that "makes it work" :)
             eb.WithSimpleLineContent(page.Select(g =>
             {
-                var ret = $"[`{g.Hid}`] **{g.NameFor(ctx)}** ";
+                var ret = $"[`{g.DisplayHid(ctx.Config)}`] **{g.NameFor(ctx)}** ";
 
                 switch (opts.SortProperty)
                 {
@@ -308,7 +308,7 @@ public static class ContextListExt
         {
             foreach (var g in page)
             {
-                var profile = new StringBuilder($"**ID**: {g.Hid}");
+                var profile = new StringBuilder($"**ID**: {g.DisplayHid(ctx.Config)}");
 
                 if (g.DisplayName != null && g.NamePrivacy.CanAccess(lookupCtx))
                     profile.Append($"\n**Display name**: {g.DisplayName}");

--- a/PluralKit.Bot/Commands/Member.cs
+++ b/PluralKit.Bot/Commands/Member.cs
@@ -101,12 +101,12 @@ public class Member
 
         // Send confirmation and space hint
         await ctx.Reply(
-            $"{Emojis.Success} Member \"{memberName}\" (`{member.Hid}`) registered! Check out the getting started page for how to get a member up and running: https://pluralkit.me/start#create-a-member");
+            $"{Emojis.Success} Member \"{memberName}\" (`{member.DisplayHid(ctx.Config)}`) registered! Check out the getting started page for how to get a member up and running: https://pluralkit.me/start#create-a-member");
         // todo: move this to ModelRepository
         if (await ctx.Database.Execute(conn => conn.QuerySingleAsync<bool>("select has_private_members(@System)",
                 new { System = ctx.System.Id })) && !ctx.Config.MemberDefaultPrivate) //if has private members
             await ctx.Reply(
-                $"{Emojis.Warn} This member is currently **public**. To change this, use `pk;member {member.Hid} private`.");
+                $"{Emojis.Warn} This member is currently **public**. To change this, use `pk;member {member.DisplayHid(ctx.Config)} private`.");
         if (avatarArg != null)
             if (imageMatchError == null)
                 await ctx.Reply(
@@ -115,7 +115,7 @@ public class Member
                 await ctx.Reply($"{Emojis.Error} Couldn't set avatar: {imageMatchError.Message}");
         if (memberName.Contains(" "))
             await ctx.Reply(
-                $"{Emojis.Note} Note that this member's name contains spaces. You will need to surround it with \"double quotes\" when using commands referring to it, or just use the member's 5-character ID (which is `{member.Hid}`).");
+                $"{Emojis.Note} Note that this member's name contains spaces. You will need to surround it with \"double quotes\" when using commands referring to it, or just use the member's short ID (which is `{member.DisplayHid(ctx.Config)}`).");
         if (memberCount >= memberLimit)
             await ctx.Reply(
                 $"{Emojis.Warn} You have reached the per-system member limit ({memberLimit}). If you need to add more members, you can either delete existing members, or ask for your limit to be raised in the PluralKit support server: <https://discord.gg/PczBt78>");
@@ -128,7 +128,7 @@ public class Member
     {
         var system = await ctx.Repository.GetSystem(target.System);
         await ctx.Reply(
-            embed: await _embeds.CreateMemberEmbed(system, target, ctx.Guild, ctx.LookupContextFor(system.Id), ctx.Zone));
+            embed: await _embeds.CreateMemberEmbed(system, target, ctx.Guild, ctx.Config, ctx.LookupContextFor(system.Id), ctx.Zone));
     }
 
     public async Task Soulscream(Context ctx, PKMember target)
@@ -156,6 +156,6 @@ public class Member
 
     public async Task DisplayId(Context ctx, PKMember target)
     {
-        await ctx.Reply(target.Hid);
+        await ctx.Reply(target.DisplayHid(ctx.Config));
     }
 }

--- a/PluralKit.Bot/Commands/MemberEdit.cs
+++ b/PluralKit.Bot/Commands/MemberEdit.cs
@@ -816,8 +816,8 @@ public class MemberEdit
         ctx.CheckSystem().CheckOwnMember(target);
 
         await ctx.Reply(
-            $"{Emojis.Warn} Are you sure you want to delete \"{target.NameFor(ctx)}\"? If so, reply to this message with the member's ID (`{target.Hid}`). __***This cannot be undone!***__");
-        if (!await ctx.ConfirmWithReply(target.Hid)) throw Errors.MemberDeleteCancelled;
+            $"{Emojis.Warn} Are you sure you want to delete \"{target.NameFor(ctx)}\"? If so, reply to this message with the member's ID (`{target.DisplayHid(ctx.Config)}`). __***This cannot be undone!***__");
+        if (!await ctx.ConfirmWithReply(target.Hid, treatAsHid: true)) throw Errors.MemberDeleteCancelled;
 
         await ctx.Repository.DeleteMember(target.Id);
 

--- a/PluralKit.Bot/Commands/MemberEdit.cs
+++ b/PluralKit.Bot/Commands/MemberEdit.cs
@@ -36,7 +36,7 @@ public class MemberEdit
         if (existingMember != null && existingMember.Id != target.Id)
         {
             var msg =
-                $"{Emojis.Warn} You already have a member in your system with the name \"{existingMember.NameFor(ctx)}\" (`{existingMember.Hid}`). Do you want to rename this member to that name too?";
+                $"{Emojis.Warn} You already have a member in your system with the name \"{existingMember.NameFor(ctx)}\" (`{existingMember.DisplayHid(ctx.Config)}`). Do you want to rename this member to that name too?";
             if (!await ctx.PromptYesNo(msg, "Rename")) throw new PKError("Member renaming cancelled.");
         }
 
@@ -47,7 +47,7 @@ public class MemberEdit
         await ctx.Reply($"{Emojis.Success} Member renamed (using {newName.Length}/{Limits.MaxMemberNameLength} characters).");
         if (newName.Contains(" "))
             await ctx.Reply(
-                $"{Emojis.Note} Note that this member's name now contains spaces. You will need to surround it with \"double quotes\" when using commands referring to it, or just use the member's 5-character ID (which is `{target.Hid}`).");
+                $"{Emojis.Note} Note that this member's name now contains spaces. You will need to surround it with \"double quotes\" when using commands referring to it, or just use the member's short ID (which is `{target.DisplayHid(ctx.Config)}`).");
         if (target.DisplayName != null)
             await ctx.Reply(
                 $"{Emojis.Note} Note that this member has a display name set ({target.DisplayName}), and will be proxied using that name instead.");
@@ -211,7 +211,7 @@ public class MemberEdit
                 var eb = new EmbedBuilder()
                     .Title($"{target.NameFor(ctx)}'s banner image")
                     .Image(new Embed.EmbedImage(target.BannerImage))
-                    .Description($"To clear, use `pk;member {target.Hid} banner clear`.");
+                    .Description($"To clear, use `pk;member {target.Reference(ctx)} banner clear`.");
                 await ctx.Reply(embed: eb.Build());
             }
             else

--- a/PluralKit.Bot/Commands/Random.cs
+++ b/PluralKit.Bot/Commands/Random.cs
@@ -37,7 +37,7 @@ public class Random
 
         var randInt = randGen.Next(members.Count);
         await ctx.Reply(embed: await _embeds.CreateMemberEmbed(target, members[randInt], ctx.Guild,
-            ctx.LookupContextFor(target.Id), ctx.Zone));
+            ctx.Config, ctx.LookupContextFor(target.Id), ctx.Zone));
     }
 
     public async Task Group(Context ctx, PKSystem target)
@@ -93,6 +93,6 @@ public class Random
 
         var randInt = randGen.Next(ms.Count);
         await ctx.Reply(embed: await _embeds.CreateMemberEmbed(system, ms[randInt], ctx.Guild,
-            ctx.LookupContextFor(group.System), ctx.Zone));
+            ctx.Config, ctx.LookupContextFor(group.System), ctx.Zone));
     }
 }

--- a/PluralKit.Bot/Commands/System.cs
+++ b/PluralKit.Bot/Commands/System.cs
@@ -39,6 +39,6 @@ public class System
         if (target == null)
             throw Errors.NoSystemError;
 
-        await ctx.Reply(target.Hid);
+        await ctx.Reply(target.DisplayHid(ctx.Config));
     }
 }

--- a/PluralKit.Bot/Commands/SystemList.cs
+++ b/PluralKit.Bot/Commands/SystemList.cs
@@ -33,11 +33,11 @@ public class SystemList
 
         var systemGuildSettings = ctx.Guild != null ? await ctx.Repository.GetSystemGuild(ctx.Guild.Id, target.Id) : null;
         if (systemGuildSettings != null && systemGuildSettings.DisplayName != null)
-            title.Append($"{systemGuildSettings.DisplayName}  (`{target.Hid}`)");
+            title.Append($"{systemGuildSettings.DisplayName}  (`{target.DisplayHid(ctx.Config)}`)");
         else if (target.NameFor(ctx) != null)
-            title.Append($"{target.NameFor(ctx)} (`{target.Hid}`)");
+            title.Append($"{target.NameFor(ctx)} (`{target.DisplayHid(ctx.Config)}`)");
         else
-            title.Append($"`{target.Hid}`");
+            title.Append($"`{target.DisplayHid(ctx.Config)}`");
 
         if (opts.Search != null)
             title.Append($" matching **{opts.Search.Truncate(100)}**");

--- a/PluralKit.Bot/Handlers/InteractionCreated.cs
+++ b/PluralKit.Bot/Handlers/InteractionCreated.cs
@@ -16,20 +16,23 @@ public class InteractionCreated: IEventHandler<InteractionCreateEvent>
     private readonly ApplicationCommandTree _commandTree;
     private readonly ILifetimeScope _services;
     private readonly ILogger _logger;
+    private readonly ModelRepository _repo;
 
     public InteractionCreated(InteractionDispatchService interactionDispatch, ApplicationCommandTree commandTree,
-                              ILifetimeScope services, ILogger logger)
+                              ILifetimeScope services, ILogger logger, ModelRepository repo)
     {
         _interactionDispatch = interactionDispatch;
         _commandTree = commandTree;
         _services = services;
         _logger = logger;
+        _repo = repo;
     }
 
     public async Task Handle(int shardId, InteractionCreateEvent evt)
     {
-        var system = await _services.Resolve<ModelRepository>().GetSystemByAccount(evt.Member?.User.Id ?? evt.User!.Id);
-        var ctx = new InteractionContext(_services, evt, system);
+        var system = await _repo.GetSystemByAccount(evt.Member?.User.Id ?? evt.User!.Id);
+        var config = system != null ? await _repo.GetSystemConfig(system!.Id) : null;
+        var ctx = new InteractionContext(_services, evt, system, config);
 
         switch (evt.Type)
         {

--- a/PluralKit.Bot/Handlers/ReactionAdded.cs
+++ b/PluralKit.Bot/Handlers/ReactionAdded.cs
@@ -175,6 +175,8 @@ public class ReactionAdded: IEventHandler<MessageReactionAddEvent>
     private async ValueTask HandleQueryReaction(MessageReactionAddEvent evt, FullMessage msg)
     {
         var guild = await _cache.GetGuild(evt.GuildId!.Value);
+        var system = await _repo.GetSystemByAccount(evt.UserId);
+        var config = system != null ? await _repo.GetSystemConfig(system.Id) : null;
 
         // Try to DM the user info about the message
         try
@@ -188,11 +190,12 @@ public class ReactionAdded: IEventHandler<MessageReactionAddEvent>
                     msg.System,
                     msg.Member,
                     guild,
+                    config,
                     LookupContext.ByNonOwner,
                     DateTimeZone.Utc
                 ));
 
-            embeds.Add(await _embeds.CreateMessageInfoEmbed(msg, true));
+            embeds.Add(await _embeds.CreateMessageInfoEmbed(msg, true, config));
 
             await _rest.CreateMessage(dm, new MessageRequest { Embeds = embeds.ToArray() });
         }

--- a/PluralKit.Bot/Services/EmbedService.cs
+++ b/PluralKit.Bot/Services/EmbedService.cs
@@ -70,7 +70,7 @@ public class EmbedService
         var eb = new EmbedBuilder()
             .Title(system.NameFor(ctx))
             .Footer(new Embed.EmbedFooter(
-                $"System ID: {system.Hid} | Created on {system.Created.FormatZoned(cctx.Zone)}"))
+                $"System ID: {system.DisplayHid(cctx.Config)} | Created on {system.Created.FormatZoned(cctx.Zone)}"))
             .Color(color)
             .Url($"https://dash.pluralkit.me/profile/s/{system.Hid}");
 
@@ -90,7 +90,7 @@ public class EmbedService
             {
                 var memberStr = string.Join(", ", switchMembers.Select(m => m.NameFor(ctx)));
                 if (memberStr.Length > 200)
-                    memberStr = $"[too many to show, see `pk;system {system.Hid} fronters`]";
+                    memberStr = $"[too many to show, see `pk;system {system.DisplayHid(cctx.Config)} fronters`]";
                 eb.Field(new Embed.Field("Fronter".ToQuantity(switchMembers.Count, ShowQuantityAs.None), memberStr));
             }
         }
@@ -137,7 +137,7 @@ public class EmbedService
         {
             if (memberCount > 0)
                 eb.Field(new Embed.Field($"Members ({memberCount})",
-                    $"(see `pk;system {system.Hid} list` or `pk;system {system.Hid} list full`)", true));
+                    $"(see `pk;system {system.DisplayHid(cctx.Config)} list` or `pk;system {system.DisplayHid(cctx.Config)} list full`)", true));
             else
                 eb.Field(new Embed.Field($"Members ({memberCount})", "Add one with `pk;member new`!", true));
         }
@@ -175,7 +175,7 @@ public class EmbedService
         return embed.Build();
     }
 
-    public async Task<Embed> CreateMemberEmbed(PKSystem system, PKMember member, Guild guild, LookupContext ctx, DateTimeZone zone)
+    public async Task<Embed> CreateMemberEmbed(PKSystem system, PKMember member, Guild guild, SystemConfig? ccfg, LookupContext ctx, DateTimeZone zone)
     {
         // string FormatTimestamp(Instant timestamp) => DateTimeFormats.ZonedDateTimeFormat.Format(timestamp.InZone(system.Zone));
 
@@ -216,7 +216,7 @@ public class EmbedService
             // .WithColor(member.ColorPrivacy.CanAccess(ctx) ? color : DiscordUtils.Gray)
             .Color(color)
             .Footer(new Embed.EmbedFooter(
-                $"System ID: {system.Hid} | Member ID: {member.Hid} {(member.MetadataPrivacy.CanAccess(ctx) ? $"| Created on {member.Created.FormatZoned(zone)}" : "")}"));
+                $"System ID: {system.DisplayHid(ccfg)} | Member ID: {member.DisplayHid(ccfg)} {(member.MetadataPrivacy.CanAccess(ctx) ? $"| Created on {member.Created.FormatZoned(zone)}" : "")}"));
 
         if (member.DescriptionPrivacy.CanAccess(ctx))
             eb.Image(new Embed.EmbedImage(member.BannerImage));
@@ -304,7 +304,7 @@ public class EmbedService
             .Author(new Embed.EmbedAuthor(nameField, IconUrl: target.IconFor(pctx), Url: $"https://dash.pluralkit.me/profile/g/{target.Hid}"))
             .Color(color);
 
-        eb.Footer(new Embed.EmbedFooter($"System ID: {system.Hid} | Group ID: {target.Hid}{(target.MetadataPrivacy.CanAccess(pctx) ? $" | Created on {target.Created.FormatZoned(ctx.Zone)}" : "")}"));
+        eb.Footer(new Embed.EmbedFooter($"System ID: {system.DisplayHid(ctx.Config)} | Group ID: {target.DisplayHid(ctx.Config)}{(target.MetadataPrivacy.CanAccess(pctx) ? $" | Created on {target.Created.FormatZoned(ctx.Zone)}" : "")}"));
 
         if (target.DescriptionPrivacy.CanAccess(pctx))
             eb.Image(new Embed.EmbedImage(target.BannerImage));
@@ -369,7 +369,7 @@ public class EmbedService
             .Build();
     }
 
-    public async Task<Embed> CreateMessageInfoEmbed(FullMessage msg, bool showContent)
+    public async Task<Embed> CreateMessageInfoEmbed(FullMessage msg, bool showContent, SystemConfig? ccfg = null)
     {
         var channel = await _cache.GetOrFetchChannel(_rest, msg.Message.Channel);
         var ctx = LookupContext.ByNonOwner;
@@ -424,12 +424,12 @@ public class EmbedService
             .Field(new Embed.Field("System",
                 msg.System == null
                     ? "*(deleted or unknown system)*"
-                    : msg.System.NameFor(ctx) != null ? $"{msg.System.NameFor(ctx)} (`{msg.System.Hid}`)" : $"`{msg.System.Hid}`"
+                    : msg.System.NameFor(ctx) != null ? $"{msg.System.NameFor(ctx)} (`{msg.System.DisplayHid(ccfg)}`)" : $"`{msg.System.DisplayHid(ccfg)}`"
             , true))
             .Field(new Embed.Field("Member",
                 msg.Member == null
                     ? "*(deleted member)*"
-                    : $"{msg.Member.NameFor(ctx)} (`{msg.Member.Hid}`)"
+                    : $"{msg.Member.NameFor(ctx)} (`{msg.Member.DisplayHid(ccfg)}`)"
             , true))
             .Field(new Embed.Field("Sent by", userStr, true))
             .Timestamp(DiscordUtils.SnowflakeToInstant(msg.Message.Mid).ToDateTimeOffset().ToString("O"))

--- a/PluralKit.Bot/Utils/ContextUtils.cs
+++ b/PluralKit.Bot/Utils/ContextUtils.cs
@@ -55,7 +55,7 @@ public static class ContextUtils
             .WaitFor(ReactionPredicate, timeout);
     }
 
-    public static async Task<bool> ConfirmWithReply(this Context ctx, string expectedReply)
+    public static async Task<bool> ConfirmWithReply(this Context ctx, string expectedReply, bool treatAsHid = false)
     {
         bool Predicate(MessageCreateEvent e) =>
             e.Author.Id == ctx.Author.Id && e.ChannelId == ctx.Channel.Id;
@@ -63,7 +63,11 @@ public static class ContextUtils
         var msg = await ctx.Services.Resolve<HandlerQueue<MessageCreateEvent>>()
             .WaitFor(Predicate, Duration.FromMinutes(1));
 
-        return string.Equals(msg.Content, expectedReply, StringComparison.InvariantCultureIgnoreCase);
+        var content = msg.Content;
+        if (treatAsHid)
+            content = content.ToLower().Replace("-", null);
+
+        return string.Equals(content, expectedReply, StringComparison.InvariantCultureIgnoreCase);
     }
 
     public static async Task Paginate<T>(this Context ctx, IAsyncEnumerable<T> items, int totalCount,

--- a/PluralKit.Bot/Utils/InteractionContext.cs
+++ b/PluralKit.Bot/Utils/InteractionContext.cs
@@ -16,10 +16,11 @@ public class InteractionContext
     private readonly ILifetimeScope _provider;
     private readonly IMetrics _metrics;
 
-    public InteractionContext(ILifetimeScope provider, InteractionCreateEvent evt, PKSystem system)
+    public InteractionContext(ILifetimeScope provider, InteractionCreateEvent evt, PKSystem system, SystemConfig config)
     {
         Event = evt;
         System = system;
+        Config = config;
         Cache = provider.Resolve<IDiscordCache>();
         Rest = provider.Resolve<DiscordApiClient>();
         Repository = provider.Resolve<ModelRepository>();
@@ -31,6 +32,7 @@ public class InteractionContext
     internal readonly DiscordApiClient Rest;
     internal readonly ModelRepository Repository;
     public readonly PKSystem System;
+    public readonly SystemConfig Config;
 
     public InteractionCreateEvent Event { get; }
 

--- a/PluralKit.Bot/Utils/ModelUtils.cs
+++ b/PluralKit.Bot/Utils/ModelUtils.cs
@@ -31,7 +31,12 @@ public static class ModelUtils
     public static string DisplayHid(this PKSystem system, SystemConfig? cfg = null) => HidTransform(system.Hid, cfg);
     public static string DisplayHid(this PKGroup group, SystemConfig? cfg = null) => HidTransform(group.Hid, cfg);
     public static string DisplayHid(this PKMember member, SystemConfig? cfg = null) => HidTransform(member.Hid, cfg);
-    private static string HidTransform(string hid, SystemConfig? cfg = null) => HidUtils.HidTransform(hid, cfg != null && cfg.HidDisplaySplit);
+    private static string HidTransform(string hid, SystemConfig? cfg = null) =>
+        HidUtils.HidTransform(
+            hid,
+            cfg != null && cfg.HidDisplaySplit,
+            cfg != null && cfg.HidDisplayCaps
+        );
 
     private static string EntityReference(string hid, string name)
     {

--- a/PluralKit.Bot/Utils/ModelUtils.cs
+++ b/PluralKit.Bot/Utils/ModelUtils.cs
@@ -24,8 +24,14 @@ public static class ModelUtils
     public static string DisplayName(this PKMember member) =>
         member.DisplayName ?? member.Name;
 
-    public static string Reference(this PKMember member, Context ctx) => EntityReference(member.Hid, member.NameFor(ctx));
-    public static string Reference(this PKGroup group, Context ctx) => EntityReference(group.Hid, group.NameFor(ctx));
+    public static string Reference(this PKMember member, Context ctx) => EntityReference(member.DisplayHid(ctx.Config), member.NameFor(ctx));
+    public static string Reference(this PKGroup group, Context ctx) => EntityReference(group.DisplayHid(ctx.Config), group.NameFor(ctx));
+
+
+    public static string DisplayHid(this PKSystem system, SystemConfig? cfg = null) => HidTransform(system.Hid, cfg);
+    public static string DisplayHid(this PKGroup group, SystemConfig? cfg = null) => HidTransform(group.Hid, cfg);
+    public static string DisplayHid(this PKMember member, SystemConfig? cfg = null) => HidTransform(member.Hid, cfg);
+    private static string HidTransform(string hid, SystemConfig? cfg = null) => HidUtils.HidTransform(hid, cfg != null && cfg.HidDisplaySplit);
 
     private static string EntityReference(string hid, string name)
     {

--- a/PluralKit.Core/Database/Functions/functions.sql
+++ b/PluralKit.Core/Database/Functions/functions.sql
@@ -122,13 +122,13 @@ begin
 end
 $$ language plpgsql;
 
-create function generate_hid() returns char(5) as $$
-    select string_agg(substr('abcdefghijklmnopqrstuvwxyz', ceil(random() * 26)::integer, 1), '') from generate_series(1, 5)
+create function generate_hid() returns char(6) as $$
+    select string_agg(substr('abcefghjknoprstuvwxyz', ceil(random() * 21)::integer, 1), '') from generate_series(1, 6)
 $$ language sql volatile;
 
 
-create function find_free_system_hid() returns char(5) as $$
-declare new_hid char(5);
+create function find_free_system_hid() returns char(6) as $$
+declare new_hid char(6);
 begin
     loop
         new_hid := generate_hid();
@@ -138,8 +138,8 @@ end
 $$ language plpgsql volatile;
 
 
-create function find_free_member_hid() returns char(5) as $$
-declare new_hid char(5);
+create function find_free_member_hid() returns char(6) as $$
+declare new_hid char(6);
 begin
     loop
         new_hid := generate_hid();
@@ -148,8 +148,9 @@ begin
 end
 $$ language plpgsql volatile;
 
-create function find_free_group_hid() returns char(5) as $$
-declare new_hid char(5);
+
+create function find_free_group_hid() returns char(6) as $$
+declare new_hid char(6);
 begin
     loop
         new_hid := generate_hid();

--- a/PluralKit.Core/Database/Migrations/42.sql
+++ b/PluralKit.Core/Database/Migrations/42.sql
@@ -1,0 +1,10 @@
+-- database version 42
+-- move to 6 character HIDs, add HID display config setting
+
+alter table systems alter column hid type char(6) using rpad(hid, 6, ' ');
+alter table members alter column hid type char(6) using rpad(hid, 6, ' ');
+alter table groups alter column hid type char(6) using rpad(hid, 6, ' ');
+
+alter table system_config add column hid_display_split bool default false;
+
+update info set schema_version = 42;

--- a/PluralKit.Core/Database/Migrations/42.sql
+++ b/PluralKit.Core/Database/Migrations/42.sql
@@ -6,5 +6,6 @@ alter table members alter column hid type char(6) using rpad(hid, 6, ' ');
 alter table groups alter column hid type char(6) using rpad(hid, 6, ' ');
 
 alter table system_config add column hid_display_split bool default false;
+alter table system_config add column hid_display_caps bool default false;
 
 update info set schema_version = 42;

--- a/PluralKit.Core/Database/Utils/DatabaseMigrator.cs
+++ b/PluralKit.Core/Database/Utils/DatabaseMigrator.cs
@@ -9,7 +9,7 @@ namespace PluralKit.Core;
 internal class DatabaseMigrator
 {
     private const string RootPath = "PluralKit.Core.Database"; // "resource path" root for SQL files
-    private const int TargetSchemaVersion = 41;
+    private const int TargetSchemaVersion = 42;
     private readonly ILogger _logger;
 
     public DatabaseMigrator(ILogger logger)

--- a/PluralKit.Core/Database/Utils/HidUtils.cs
+++ b/PluralKit.Core/Database/Utils/HidUtils.cs
@@ -1,0 +1,35 @@
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace PluralKit.Core;
+
+public static class HidUtils
+{
+    private static readonly Regex _hidRegex = new(@"^[a-zA-Z]{5,6}$");
+
+    public static string? ParseHid(string input)
+    {
+        input = input.ToLower().Replace("-", null);
+        if (!_hidRegex.IsMatch(input))
+            return null;
+
+        return input;
+    }
+
+    public static bool TryParseHid(this string input, out string hid)
+    {
+        hid = ParseHid(input);
+        return hid != null;
+    }
+
+    public static string HidTransform(string input, bool split = false)
+    {
+        if (split && input.Length > 5)
+        {
+            var len = (int)Math.Floor(input.Length / 2.0);
+            input = string.Concat(input.AsSpan(0, len), "-", input.AsSpan(len));
+        }
+
+        return input;
+    }
+}

--- a/PluralKit.Core/Database/Utils/HidUtils.cs
+++ b/PluralKit.Core/Database/Utils/HidUtils.cs
@@ -22,13 +22,16 @@ public static class HidUtils
         return hid != null;
     }
 
-    public static string HidTransform(string input, bool split = false)
+    public static string HidTransform(string input, bool split, bool caps)
     {
         if (split && input.Length > 5)
         {
             var len = (int)Math.Floor(input.Length / 2.0);
             input = string.Concat(input.AsSpan(0, len), "-", input.AsSpan(len));
         }
+
+        if (caps)
+            input = input.ToUpper();
 
         return input;
     }

--- a/PluralKit.Core/Database/clean.sql
+++ b/PluralKit.Core/Database/clean.sql
@@ -3,6 +3,7 @@
 -- This does mean we can't use any functions in row triggers, etc. Still unsure how to handle this.
 
 drop view if exists system_last_switch;
+drop view if exists system_fronters;
 drop view if exists member_list;
 drop view if exists group_list;
 

--- a/PluralKit.Core/Models/PKGroup.cs
+++ b/PluralKit.Core/Models/PKGroup.cs
@@ -32,7 +32,13 @@ public readonly struct GroupId: INumericId<GroupId, int>
 public class PKGroup
 {
     public GroupId Id { get; private set; }
-    public string Hid { get; private set; } = null!;
+    private string _hid = null!;
+    public string Hid
+    {
+        private set => _hid = value.Trim();
+        get => _hid;
+    }
+
     public Guid Uuid { get; private set; }
     public SystemId System { get; private set; }
 

--- a/PluralKit.Core/Models/PKMember.cs
+++ b/PluralKit.Core/Models/PKMember.cs
@@ -35,7 +35,13 @@ public class PKMember
     // Dapper *can* figure out mapping to getter-only properties, but this doesn't work
     // when trying to map to *subclasses* (eg. ListedMember). Adding private setters makes it work anyway.
     public MemberId Id { get; private set; }
-    public string Hid { get; private set; }
+    private string _hid = null!;
+    public string Hid
+    {
+        private set => _hid = value.Trim();
+        get => _hid;
+    }
+
     public Guid Uuid { get; private set; }
     public SystemId System { get; private set; }
     public string Color { get; private set; }

--- a/PluralKit.Core/Models/PKSystem.cs
+++ b/PluralKit.Core/Models/PKSystem.cs
@@ -33,7 +33,13 @@ public readonly struct SystemId: INumericId<SystemId, int>
 public class PKSystem
 {
     [Key] public SystemId Id { get; }
-    public string Hid { get; }
+    private string _hid = null!;
+    public string Hid
+    {
+        private set => _hid = value.Trim();
+        get => _hid;
+    }
+
     public Guid Uuid { get; private set; }
     public string Name { get; }
     public string Description { get; }

--- a/PluralKit.Core/Models/Patch/SystemConfigPatch.cs
+++ b/PluralKit.Core/Models/Patch/SystemConfigPatch.cs
@@ -20,6 +20,7 @@ public class SystemConfigPatch: PatchObject
     public Partial<bool> CaseSensitiveProxyTags { get; set; }
     public Partial<bool> ProxyErrorMessageEnabled { get; set; }
     public Partial<bool> HidDisplaySplit { get; set; }
+    public Partial<bool> HidDisplayCaps { get; set; }
 
 
     public override Query Apply(Query q) => q.ApplyPatch(wrapper => wrapper
@@ -35,6 +36,7 @@ public class SystemConfigPatch: PatchObject
         .With("case_sensitive_proxy_tags", CaseSensitiveProxyTags)
         .With("proxy_error_message_enabled", ProxyErrorMessageEnabled)
         .With("hid_display_split", HidDisplaySplit)
+        .With("hid_display_caps", HidDisplayCaps)
     );
 
     public new void AssertIsValid()
@@ -93,6 +95,9 @@ public class SystemConfigPatch: PatchObject
         if (HidDisplaySplit.IsPresent)
             o.Add("hid_display_split", HidDisplaySplit.Value);
 
+        if (HidDisplayCaps.IsPresent)
+            o.Add("hid_display_caps", HidDisplayCaps.Value);
+
         return o;
     }
 
@@ -126,6 +131,9 @@ public class SystemConfigPatch: PatchObject
 
         if (o.ContainsKey("hid_display_split"))
             patch.HidDisplaySplit = o.Value<bool>("hid_display_split");
+
+        if (o.ContainsKey("hid_display_caps"))
+            patch.HidDisplayCaps = o.Value<bool>("hid_display_caps");
 
         return patch;
     }

--- a/PluralKit.Core/Models/Patch/SystemConfigPatch.cs
+++ b/PluralKit.Core/Models/Patch/SystemConfigPatch.cs
@@ -19,6 +19,7 @@ public class SystemConfigPatch: PatchObject
     public Partial<string[]> DescriptionTemplates { get; set; }
     public Partial<bool> CaseSensitiveProxyTags { get; set; }
     public Partial<bool> ProxyErrorMessageEnabled { get; set; }
+    public Partial<bool> HidDisplaySplit { get; set; }
 
 
     public override Query Apply(Query q) => q.ApplyPatch(wrapper => wrapper
@@ -33,6 +34,7 @@ public class SystemConfigPatch: PatchObject
         .With("description_templates", DescriptionTemplates)
         .With("case_sensitive_proxy_tags", CaseSensitiveProxyTags)
         .With("proxy_error_message_enabled", ProxyErrorMessageEnabled)
+        .With("hid_display_split", HidDisplaySplit)
     );
 
     public new void AssertIsValid()
@@ -88,6 +90,9 @@ public class SystemConfigPatch: PatchObject
         if (ProxyErrorMessageEnabled.IsPresent)
             o.Add("proxy_error_message_enabled", ProxyErrorMessageEnabled.Value);
 
+        if (HidDisplaySplit.IsPresent)
+            o.Add("hid_display_split", HidDisplaySplit.Value);
+
         return o;
     }
 
@@ -118,6 +123,9 @@ public class SystemConfigPatch: PatchObject
 
         if (o.ContainsKey("proxy_error_message_enabled"))
             patch.ProxyErrorMessageEnabled = o.Value<bool>("proxy_error_message_enabled");
+
+        if (o.ContainsKey("hid_display_split"))
+            patch.HidDisplaySplit = o.Value<bool>("hid_display_split");
 
         return patch;
     }

--- a/PluralKit.Core/Models/SystemConfig.cs
+++ b/PluralKit.Core/Models/SystemConfig.cs
@@ -22,6 +22,7 @@ public class SystemConfig
     public bool CaseSensitiveProxyTags { get; }
     public bool ProxyErrorMessageEnabled { get; }
     public bool HidDisplaySplit { get; }
+    public bool HidDisplayCaps { get; }
 }
 
 public static class SystemConfigExt
@@ -41,6 +42,7 @@ public static class SystemConfigExt
         o.Add("case_sensitive_proxy_tags", cfg.CaseSensitiveProxyTags);
         o.Add("proxy_error_message_enabled", cfg.ProxyErrorMessageEnabled);
         o.Add("hid_display_split", cfg.HidDisplaySplit);
+        o.Add("hid_display_caps", cfg.HidDisplayCaps);
 
         o.Add("description_templates", JArray.FromObject(cfg.DescriptionTemplates));
 

--- a/PluralKit.Core/Models/SystemConfig.cs
+++ b/PluralKit.Core/Models/SystemConfig.cs
@@ -19,8 +19,9 @@ public class SystemConfig
 
     public DateTimeZone Zone => DateTimeZoneProviders.Tzdb.GetZoneOrNull(UiTz);
 
-    public bool CaseSensitiveProxyTags { get; set; }
+    public bool CaseSensitiveProxyTags { get; }
     public bool ProxyErrorMessageEnabled { get; }
+    public bool HidDisplaySplit { get; }
 }
 
 public static class SystemConfigExt
@@ -39,6 +40,7 @@ public static class SystemConfigExt
         o.Add("group_limit", cfg.GroupLimitOverride ?? Limits.MaxGroupCount);
         o.Add("case_sensitive_proxy_tags", cfg.CaseSensitiveProxyTags);
         o.Add("proxy_error_message_enabled", cfg.ProxyErrorMessageEnabled);
+        o.Add("hid_display_split", cfg.HidDisplaySplit);
 
         o.Add("description_templates", JArray.FromObject(cfg.DescriptionTemplates));
 

--- a/docs/content/api/changelog.md
+++ b/docs/content/api/changelog.md
@@ -5,6 +5,8 @@ permalink: /api/changelog
 
 # Version history
 
+* 2024-05-01
+  * Short IDs (the `id` field in system / member / group models) can now be either 5 or 6 characters.
 * 2022-12-14
   * Added keys to member model: `autoproxy_enabled` (own-system only), `message_count` and `last_message_timestamp` (under metadata privacy)
 * 2022-01-11

--- a/docs/content/api/endpoints.md
+++ b/docs/content/api/endpoints.md
@@ -12,7 +12,7 @@ All query string parameters are optional, but if present they require a non-null
 ---
 ## Systems
 
-*`systemRef` can be a system's short (5-character) ID, a system's UUID, the ID of a Discord account linked to the system, or the string `@me` to refer to the currently authenticated system.*
+*`systemRef` can be a system's short (5 or 6 character) ID, a system's UUID, the ID of a Discord account linked to the system, or the string `@me` to refer to the currently authenticated system.*
 
 ### Get System
 
@@ -97,7 +97,7 @@ Currently, only autoproxy with `guild_id` is supported. The API will return an e
 ---
 ## Members
 
-*`memberRef` can be a member's short (5-character ID) or a member's UUID.*
+*`memberRef` can be a member's short (5 or 6 character ID) or a member's UUID.*
 
 ### Get System Members
 
@@ -180,7 +180,7 @@ Returns a [member guild settings](/api/models#member-guild-settings-model) objec
 ---
 ## Groups
 
-*`groupRef` can be a group's short (5-character ID) or a group's UUID.*
+*`groupRef` can be a group's short (5 or 6 character ID) or a group's UUID.*
 
 ### Get System Groups
 
@@ -252,7 +252,7 @@ Takes an array of member references as input. (An empty list is accepted.) Retur
 ---
 ## Switches
 
-*`switchRef` must be a switch's UUID. `systemRef` can be a system's short (5-character) ID, a system's UUID, the ID of a Discord account linked to the system, or the string `@me` to refer to the currently authenticated system.*
+*`switchRef` must be a switch's UUID. `systemRef` can be a system's short (5 or 6 character) ID, a system's UUID, the ID of a Discord account linked to the system, or the string `@me` to refer to the currently authenticated system.*
 
 
 ### Get System Switches

--- a/docs/content/api/models.md
+++ b/docs/content/api/models.md
@@ -14,7 +14,7 @@ Privacy objects (`privacy` key in models) contain values "private" or "public". 
 
 #### Notes on IDs
 
-Every PluralKit entity has two IDs: a short (5-character) ID and a longer UUID. The short ID is unique across the resource (a member can have the same short ID as a system, for example), while the UUID is consistent for the lifetime of the entity and globally unique across the bot.
+Every PluralKit entity has two IDs: a short (5 or 6 character) ID and a longer UUID. The short ID is unique across the resource (a member can have the same short ID as a system, for example), while the UUID is consistent for the lifetime of the entity and globally unique across the bot.
 
 ### System model
 

--- a/docs/content/command-list.md
+++ b/docs/content/command-list.md
@@ -46,7 +46,7 @@ You can have a space after `pk;`, e.g. `pk;system` and `pk; system` will do the 
 :::
 
 ## System commands
-*To target a specific system, replace `[system]` with that system's 5-character ID, a Discord account ID, or a @mention - note that system names can not be used here. If no system ID is specified, defaults to targeting your own system. For most commands, adding `-clear` will clear/delete the field.*
+*To target a specific system, replace `[system]` with that system's 5 or 6 character ID, a Discord account ID, or a @mention - note that system names can not be used here. If no system ID is specified, defaults to targeting your own system. For most commands, adding `-clear` will clear/delete the field.*
 - `pk;system [system]` - Shows information about a system.
 - `pk;system new [name]` - Creates a new system registered to your account.
 - `pk;system [system] rename [new name]` - Changes the name of your system.
@@ -74,7 +74,7 @@ You can have a space after `pk;`, e.g. `pk;system` and `pk; system` will do the 
 - `pk;system [system] id` - Prints a system's id. 
 
 ## Member commands
-*Replace `<member>` with a member's name, 5-character ID or display name. For most commands, adding `-clear` will clear/delete the field.*
+*Replace `<member>` with a member's name, 5 or 6 character ID, or display name. For most commands, adding `-clear` will clear/delete the field.*
 - `pk;member <member>` - Shows information about a member.
 - `pk;member new <name>` - Creates a new system member.
 - `pk;member <member> rename <new name>` - Changes the name of a member.
@@ -101,7 +101,7 @@ You can have a space after `pk;`, e.g. `pk;system` and `pk; system` will do the 
 - `pk;member <member> id` - Prints a member's id. 
 
 ## Group commands
-*Replace `<group>` with a group's name, 5-character ID or display name. For most commands, adding `-clear` will clear/delete the field.*
+*Replace `<group>` with a group's name, 5 or 6 character ID, or display name. For most commands, adding `-clear` will clear/delete the field.*
 - `pk;group <group>` - Shows information about a group.
 - `pk;group new <name>` - Creates a new group.
 - `pk;group list` - Lists all groups in your system.

--- a/docs/content/command-list.md
+++ b/docs/content/command-list.md
@@ -164,6 +164,7 @@ You can have a space after `pk;`, e.g. `pk;system` and `pk; system` will do the 
 - `pk;debug permissions [server id]` - [Checks the given server's permission setup](/staff/permissions/#permission-checker-command) to check if it's compatible with PluralKit.
 - `pk;debug proxying <message link|reply>` - Checks why your message has not been proxied.
 - `pk;edit [message link|reply] <new content>` - Edits a proxied message. Without an explicit message target, will target the last message proxied by your system in the current channel. **Does not support message IDs!**
+- `pk;edit -regex [message link|reply] <regex>` - Edits a proxied message using a C# regex. The given regex must be formatted like s\|X\|Y or s\|X\|Y\|F, where \| is any character, X is a regex pattern, Y is a substitution string, and F is a set of flags.
 - `pk;reproxy [message link|reply] <member name|ID>` - Reproxies a message using a different member. Without an explicit message target, will target the last message proxied by your system in the current channel. Only works on the last message, or within 1 minute of the proxied message being sent. Doesn't work on a non-proxied message.
 - `pk;link <account>` - Links your system to a different account.
 - `pk;unlink [account]` - Unlinks an account from your system.

--- a/docs/content/privacy-policy.md
+++ b/docs/content/privacy-policy.md
@@ -25,7 +25,7 @@ This is the data PluralKit does *not* collect:
 
 System and member information (names, member lists, descriptions, etc) are public by default, and can be looked up by anyone given a system/member ID or an account ID. This can be changed using the [privacy settings](/guide#privacy). 
 
-You can export your system information using the `pk;export` command. This does not include message metadata (as the file would be huge). If there's demand for a command to export that, [let me know on GitHub](https://github.com/PluralKit/PluralKit/issues).
+You can export your system information using the `pk;export` command. This does not include message metadata (as the file would be huge). If you wish to request a copy of the message metadata PluralKit has stored for your Discord account, ask a developer [in the support server](https://discord.gg/PczBt78).
 
 You can delete your information using `pk;system delete`. This will delete all system information and associated members, switches, and messages. This will not delete your information from the database backups. Contact me if you want that wiped, too.
 

--- a/docs/content/staff/moderation.md
+++ b/docs/content/staff/moderation.md
@@ -17,7 +17,7 @@ An example of a message card is seen below:
 ![Example of a message query card](../assets/ExampleQuery.png)
 
 ### Looking up systems and accounts
-Looking up a system by its 5-character ID (`exmpl` in the above screenshot) will show you a list of its linked account IDs. For example:
+Looking up a system by its 5 or 6 character ID (`exmpl` in the above screenshot) will show you a list of its linked account IDs. For example:
 
     pk;system exmpl
 

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -174,7 +174,7 @@ As the one exception to the rule above, if the name consists of multiple words y
 :::
 
 ### Looking up member info
-To view information about a member, there are a couple ways to do it. Either you can address a member by their name (if they're in your own system), by their 5-character *member ID*, or by their *display name*, like so:
+To view information about a member, there are a couple ways to do it. Either you can address a member by their name (if they're in your own system), by their 5 or 6 letter *member ID*, or by their *display name*, like so:
 
     pk;member John
     pk;member qazws
@@ -481,7 +481,7 @@ Then use the member's proxy tags once to set them as the latched member.
 #### Member mode 
 This autoproxy mode will autoproxy for a specific selected member, irrelevant of past proxies or fronters.
 
-To enable member-mode autoproxying for a given server, use the following command, where `<member>` is a member name (in "quotes" if multiple words) or 5-letter ID:
+To enable member-mode autoproxying for a given server, use the following command, where `<member>` is a member name (in "quotes" if multiple words), or 5 or 6 character ID:
 
     pk;autoproxy <member>
 
@@ -614,7 +614,7 @@ To create a new group, use the `pk;group new` command:
 
     pk;group new MyGroup
     
-This will create a new group. Groups all have a 5-letter ID, similar to systems and members.
+This will create a new group. Groups all have a 5 or 6 letter ID, similar to systems and members.
 
 ### Adding and removing members to groups
 To add a member to a group, use the `pk;group <group> add` command, eg:


### PR DESCRIPTION
Increases the character limit for short IDs (`hid`) to 6 characters. Existing 5-character IDs are preserved, newly generated IDs are 6 characters. 

Admin commands (and eventually, premium user commands) allow setting 5 or 6 character IDs.  

This branch is currently running on the beta bot, and no major issues have been found in testing.