### PR TITLE
feat(api): always set system id on members/groups

### DIFF
--- a/PluralKit.API/Controllers/v2/GroupControllerV2.cs
+++ b/PluralKit.API/Controllers/v2/GroupControllerV2.cs
@@ -28,7 +28,7 @@ public class GroupControllerV2: PKControllerBase
 
         var j_groups = await groups
             .Where(g => g.Visibility.CanAccess(ctx))
-            .Select(g => g.ToJson(ctx, needsMembersArray: with_members))
+            .Select(g => g.ToJson(ctx, needsMembersArray: with_members, systemStr: system.Hid))
             .ToListAsync();
 
         if (with_members && j_groups.Count > 0)
@@ -80,7 +80,7 @@ public class GroupControllerV2: PKControllerBase
 
         await tx.CommitAsync();
 
-        return Ok(newGroup.ToJson(LookupContext.ByOwner));
+        return Ok(newGroup.ToJson(LookupContext.ByOwner, system.Hid));
     }
 
     [HttpGet("groups/{groupRef}")]
@@ -127,7 +127,7 @@ public class GroupControllerV2: PKControllerBase
             throw new ModelParseError(patch.Errors);
 
         var newGroup = await _repo.UpdateGroup(group.Id, patch);
-        return Ok(newGroup.ToJson(LookupContext.ByOwner));
+        return Ok(newGroup.ToJson(LookupContext.ByOwner, system.Hid));
     }
 
     [HttpDelete("groups/{groupRef}")]

--- a/PluralKit.API/Controllers/v2/GroupMemberControllerV2.cs
+++ b/PluralKit.API/Controllers/v2/GroupMemberControllerV2.cs
@@ -19,17 +19,19 @@ public class GroupMemberControllerV2: PKControllerBase
         if (group == null)
             throw Errors.GroupNotFound;
 
+
         var ctx = ContextFor(group);
 
         if (!group.ListPrivacy.CanAccess(ctx))
             throw Errors.UnauthorizedGroupMemberList;
 
+        var system = await _repo.GetSystem(group.System);
         var members = _repo.GetGroupMembers(group.Id).Where(m => m.MemberVisibility.CanAccess(ctx));
 
         var o = new JArray();
 
         await foreach (var member in members)
-            o.Add(member.ToJson(ctx));
+            o.Add(member.ToJson(ctx, systemStr: system.Hid));
 
         return Ok(o);
     }
@@ -158,7 +160,7 @@ public class GroupMemberControllerV2: PKControllerBase
         var o = new JArray();
 
         await foreach (var group in groups)
-            o.Add(group.ToJson(ctx));
+            o.Add(group.ToJson(ctx, system.Hid));
 
         return Ok(o);
     }

--- a/PluralKit.API/Controllers/v2/MemberControllerV2.cs
+++ b/PluralKit.API/Controllers/v2/MemberControllerV2.cs
@@ -28,7 +28,7 @@ public class MemberControllerV2: PKControllerBase
         var members = _repo.GetSystemMembers(system.Id);
         return Ok(await members
             .Where(m => m.MemberVisibility.CanAccess(ctx))
-            .Select(m => m.ToJson(ctx))
+            .Select(m => m.ToJson(ctx, systemStr: system.Hid))
             .ToListAsync());
     }
 
@@ -64,7 +64,7 @@ public class MemberControllerV2: PKControllerBase
 
         await tx.CommitAsync();
 
-        return Ok(newMember.ToJson(LookupContext.ByOwner));
+        return Ok(newMember.ToJson(LookupContext.ByOwner, systemStr: system.Hid));
     }
 
     [HttpGet("members/{memberRef}")]
@@ -111,7 +111,7 @@ public class MemberControllerV2: PKControllerBase
             throw new ModelParseError(patch.Errors);
 
         var newMember = await _repo.UpdateMember(member.Id, patch);
-        return Ok(newMember.ToJson(LookupContext.ByOwner));
+        return Ok(newMember.ToJson(LookupContext.ByOwner, systemStr: system.Hid));
     }
 
     [HttpDelete("members/{memberRef}")]

--- a/PluralKit.API/Controllers/v2/SwitchControllerV2.cs
+++ b/PluralKit.API/Controllers/v2/SwitchControllerV2.cs
@@ -70,7 +70,7 @@ public class SwitchControllerV2: PKControllerBase
         return Ok(new FrontersReturnNew
         {
             Timestamp = sw.Timestamp,
-            Members = await members.Select(m => m.ToJson(ctx)).ToListAsync(),
+            Members = await members.Select(m => m.ToJson(ctx, systemStr: system.Hid)).ToListAsync(),
             Uuid = sw.Uuid,
         });
     }
@@ -124,7 +124,7 @@ public class SwitchControllerV2: PKControllerBase
         {
             Uuid = newSwitch.Uuid,
             Timestamp = data.Timestamp != null ? data.Timestamp.Value : newSwitch.Timestamp,
-            Members = members.Select(x => x.ToJson(LookupContext.ByOwner)),
+            Members = members.Select(x => x.ToJson(LookupContext.ByOwner, systemStr: system.Hid)),
         });
     }
 
@@ -153,7 +153,7 @@ public class SwitchControllerV2: PKControllerBase
         {
             Uuid = sw.Uuid,
             Timestamp = sw.Timestamp,
-            Members = await members.Select(m => m.ToJson(ctx)).ToListAsync()
+            Members = await members.Select(m => m.ToJson(ctx, systemStr: system.Hid)).ToListAsync()
         });
     }
 
@@ -190,7 +190,7 @@ public class SwitchControllerV2: PKControllerBase
         {
             Uuid = sw.Uuid,
             Timestamp = sw.Timestamp,
-            Members = members.Select(x => x.ToJson(LookupContext.ByOwner))
+            Members = members.Select(x => x.ToJson(LookupContext.ByOwner, systemStr: system.Hid))
         });
     }
 
@@ -238,7 +238,7 @@ public class SwitchControllerV2: PKControllerBase
         {
             Uuid = sw.Uuid,
             Timestamp = sw.Timestamp,
-            Members = members.Select(x => x.ToJson(LookupContext.ByOwner))
+            Members = members.Select(x => x.ToJson(LookupContext.ByOwner, systemStr: system.Hid))
         });
     }
 


### PR DESCRIPTION
This pull request sets the `system` property on members/groups across all API responses.

Reason for this change is so that all API responses are consistent in having the `system` field set.

In some cases we don't need it (i.e. `/v2/systems/{systemRef/switches/{switchRef}`) but it saves an extra API call in other cases, you'd need to separately query the group after `GET /groups/{groupRef}/members` to get the system ID.

So we figured to just make it consistent across the board