### PR TITLE
Add Quark to list of bots with PluralKit support

### DIFF
--- a/docs/content/staff/compatibility.md
+++ b/docs/content/staff/compatibility.md
@@ -8,6 +8,7 @@ Some moderation bots have official PluralKit support, and properly handle exclud
 - [**Catalogger**](https://catalogger.starshines.xyz/docs)
 - [**Aero**](https://aero.bot/) 
 - [**CoreBot**](https://discord.gg/GAAj6DDrCJ)
+- [**Quark**](https://quark.bot)
 
 If your server uses an in-house bot for logging, you can use [the API](/api) to implement support yourself.
 


### PR DESCRIPTION
https://quark.bot has native PluralKit compatibility, utilising the PluralKit API

> Quark is a logging bot in over 10k servers, which has recently added support for PluralKit. Quark will automatically ignore messages deleted by PluralKit and log messages when they are deleted within PluralKit with a ❌ reaction as the person who *originally* sent the message. It can be enabled/disabled via [the dashboard](https://quark.bot), as show in the attached image:

![image](https://github.com/PluralKit/PluralKit/assets/30315137/e7a4fd7d-368b-4f15-8a12-f69c083b1286)
