### PR TITLE
fix(api): expose x-ratelimit-* headers for browser-based applications

### DIFF
--- a/services/api/src/middleware/cors.rs
+++ b/services/api/src/middleware/cors.rs
@@ -10,6 +10,7 @@ fn add_cors_headers(headers: &mut HeaderMap) {
     headers.append("Access-Control-Allow-Methods", HeaderValue::from_static("*"));
     headers.append("Access-Control-Allow-Credentials", HeaderValue::from_static("true"));
     headers.append("Access-Control-Allow-Headers", HeaderValue::from_static("Content-Type, Authorization, sentry-trace, User-Agent"));
+    headers.append("Access-Control-Expose-Headers", HeaderValue::from_static("X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset"));
     headers.append("Access-Control-Max-Age", HeaderValue::from_static("86400"));
 }
 


### PR DESCRIPTION
This sets `Access-Control-Expose-Headers` in the API proxy responses to expose the `X-RateLimit-*` headers to CORS clients

See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers