### PR TITLE
feat(bot): add poll proxying

### DIFF
--- a/Myriad/Rest/Types/Requests/ExecuteWebhookRequest.cs
+++ b/Myriad/Rest/Types/Requests/ExecuteWebhookRequest.cs
@@ -13,4 +13,14 @@ public record ExecuteWebhookRequest
     public AllowedMentions? AllowedMentions { get; init; }
     public bool? Tts { get; init; }
     public Message.MessageFlags? Flags { get; set; }
+    public WebhookPoll? Poll { get; set; }
+
+    public record WebhookPoll
+    {
+        public Message.PollMedia Question { get; init; }
+        public Message.PollAnswer[] Answers { get; init; }
+        public int? Duration { get; init; }
+        public bool AllowMultiselect { get; init; }
+        public int LayoutType { get; init; }
+    }
 }

--- a/Myriad/Types/Message.cs
+++ b/Myriad/Types/Message.cs
@@ -70,6 +70,8 @@ public record Message
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public Optional<Message?> ReferencedMessage { get; init; }
 
+    public MessagePoll? Poll { get; init; }
+
     // public MessageComponent[]? Components { get; init; }
 
     public record Reference(ulong? GuildId, ulong? ChannelId, ulong? MessageId);
@@ -95,5 +97,18 @@ public record Message
         public int Count { get; init; }
         public bool Me { get; init; }
         public Emoji Emoji { get; init; }
+    }
+
+    public record PollMedia(string? Text, Emoji? Emoji);
+
+    public record PollAnswer(ulong AnswerId, PollMedia PollMedia);
+
+    public record MessagePoll
+    {
+        public PollMedia Question { get; init; }
+        public PollAnswer[] Answers { get; init; }
+        public string? Expiry { get; init; }
+        public bool AllowMultiselect { get; init; }
+        public int LayoutType { get; init; }
     }
 }

--- a/PluralKit.Bot/Proxy/ProxyService.cs
+++ b/PluralKit.Bot/Proxy/ProxyService.cs
@@ -189,9 +189,9 @@ public class ProxyService
             throw new ProxyChecksFailedException(
                 "Your system has proxying disabled in this server. Type `pk;proxy on` to enable it.");
 
-        // Make sure we have either an attachment or message content
+        // Make sure we have an attachment, message content, or poll
         var isMessageBlank = msg.Content == null || msg.Content.Trim().Length == 0;
-        if (isMessageBlank && msg.Attachments.Length == 0)
+        if (isMessageBlank && msg.Attachments.Length == 0 && msg.Poll == null)
             throw new ProxyChecksFailedException("Message cannot be blank.");
 
         if (msg.Activity != null)
@@ -242,6 +242,7 @@ public class ProxyService
             GuildId = trigger.GuildId!.Value,
             ChannelId = rootChannel.Id,
             ThreadId = threadId,
+            MessageId = trigger.Id,
             Name = await FixSameName(messageChannel.Id, ctx, match.Member),
             AvatarUrl = AvatarUtils.TryRewriteCdnUrl(match.Member.ProxyAvatar(ctx)),
             Content = content,
@@ -252,6 +253,7 @@ public class ProxyService
             AllowEveryone = allowEveryone,
             Flags = trigger.Flags.HasFlag(Message.MessageFlags.VoiceMessage) ? Message.MessageFlags.VoiceMessage : null,
             Tts = tts,
+            Poll = trigger.Poll,
         });
         await HandleProxyExecutedActions(ctx, autoproxySettings, trigger, proxyMessage, match);
     }
@@ -310,6 +312,7 @@ public class ProxyService
             GuildId = guild.Id,
             ChannelId = rootChannel.Id,
             ThreadId = threadId,
+            MessageId = originalMsg.Id,
             Name = match.Member.ProxyName(ctx),
             AvatarUrl = AvatarUtils.TryRewriteCdnUrl(match.Member.ProxyAvatar(ctx)),
             Content = match.ProxyContent!,
@@ -320,6 +323,7 @@ public class ProxyService
             AllowEveryone = allowEveryone,
             Flags = originalMsg.Flags.HasFlag(Message.MessageFlags.VoiceMessage) ? Message.MessageFlags.VoiceMessage : null,
             Tts = tts,
+            Poll = originalMsg.Poll,
         });
 
 

--- a/PluralKit.Bot/Services/WebhookExecutorService.cs
+++ b/PluralKit.Bot/Services/WebhookExecutorService.cs
@@ -4,6 +4,8 @@ using App.Metrics;
 
 using Humanizer;
 
+using NodaTime.Text;
+
 using Myriad.Cache;
 using Myriad.Extensions;
 using Myriad.Rest;
@@ -35,6 +37,7 @@ public record ProxyRequest
     public ulong GuildId { get; init; }
     public ulong ChannelId { get; init; }
     public ulong? ThreadId { get; init; }
+    public ulong MessageId { get; init; }
     public string Name { get; init; }
     public string? AvatarUrl { get; init; }
     public string? Content { get; init; }
@@ -45,6 +48,7 @@ public record ProxyRequest
     public bool AllowEveryone { get; init; }
     public Message.MessageFlags? Flags { get; init; }
     public bool Tts { get; init; }
+    public Message.MessagePoll? Poll { get; init; }
 }
 
 public class WebhookExecutorService
@@ -152,6 +156,26 @@ public class WebhookExecutorService
                 Waveform = f.Waveform,
                 DurationSecs = f.DurationSecs
             }).ToArray();
+        }
+
+        if (req.Poll is Message.MessagePoll poll)
+        {
+            int? duration = null;
+            if (poll.Expiry is string expiry)
+            {
+                var then = OffsetDateTimePattern.ExtendedIso.Parse(expiry).Value.ToInstant();
+                var now = DiscordUtils.SnowflakeToInstant(req.MessageId);
+                // in theory .TotalHours should be exact, but just in case
+                duration = (int)Math.Round((then - now).TotalMinutes / 60.0);
+            }
+            webhookReq.Poll = new ExecuteWebhookRequest.WebhookPoll
+            {
+                Question = poll.Question,
+                Answers = poll.Answers,
+                Duration = duration,
+                AllowMultiselect = poll.AllowMultiselect,
+                LayoutType = poll.LayoutType
+            };
         }
 
         Message webhookMessage;


### PR DESCRIPTION
This only works with autoproxy, unless we want to add tag matching against the poll question I guess. But webhooks can have polls, so why not?