### PR TITLE
Escape Discord usernames in system embed.

### DIFF
--- a/PluralKit.Bot/Services/EmbedService.cs
+++ b/PluralKit.Bot/Services/EmbedService.cs
@@ -43,7 +43,7 @@ public class EmbedService
     {
         // Fetch/render info for all accounts simultaneously
         var accounts = await _repo.GetSystemAccounts(system.Id);
-        var users = (await GetUsers(accounts)).Select(x => x.User?.NameAndMention() ?? $"(deleted account {x.Id})");
+        var users = (await GetUsers(accounts)).Select(x => x.User?.NameAndMention().EscapeMarkdownExcludingMentions() ?? $"(deleted account {x.Id})");
 
         var countctx = LookupContext.ByNonOwner;
         if (cctx.MatchFlag("a", "all"))

--- a/PluralKit.Bot/Utils/DiscordUtils.cs
+++ b/PluralKit.Bot/Utils/DiscordUtils.cs
@@ -156,6 +156,13 @@ public static class DiscordUtils
         return input;
     }
 
+    public static string EscapeMarkdownExcludingMentions(this string input)
+    {
+        var pattern = new Regex(@"[*_~`(||)\\]", RegexOptions.Multiline);
+        if (input != null) return pattern.Replace(input, @"\$&");
+        return input;
+    }
+
     public static string EscapeBacktickPair(this string input)
     {
         if (input == null)


### PR DESCRIPTION
This fixes #641 by escaping usernames correctly while preserving the inline link to the user's profile.

Please bear with me if I did anything wrong in terms of code or syntax standards. I'm more accustomed to working with Rust and most of my C# experience is with Unity.

Thank you!