### PR TITLE
Added Maki logging cleanup support (maki.gg)

### DIFF
--- a/PluralKit.Bot/Services/LoggerCleanService.cs
+++ b/PluralKit.Bot/Services/LoggerCleanService.cs
@@ -23,6 +23,7 @@ public class LoggerCleanService
     private static readonly Regex _basicRegex = new("(\\d{17,19})");
     private static readonly Regex _dynoRegex = new("Message ID: (\\d{17,19})");
     private static readonly Regex _carlRegex = new("Message ID: (\\d{17,19})");
+    private static readonly Regex _makiRegex = new("Message ID: (\\d{17,19})");
     private static readonly Regex _circleRegex = new("\\(`(\\d{17,19})`\\)");
     private static readonly Regex _loggerARegex = new("Message = (\\d{17,19})");
     private static readonly Regex _loggerBRegex = new("MessageID:(\\d{17,19})");
@@ -60,6 +61,7 @@ public class LoggerCleanService
         new LoggerBot("Dyno#8389", 470724017205149701, ExtractDyno), // webhook
         new LoggerBot("Dyno#5714", 470723870270160917, ExtractDyno), // webhook
         new LoggerBot("Dyno#1961", 347378323418251264, ExtractDyno), // webhook
+        new LoggerBot("Maki", 563434444321587202, ExtractMaki), // webhook
         new LoggerBot("Auttaja", 242730576195354624, ExtractAuttaja), // webhook
         new LoggerBot("GenericBot", 295329346590343168, ExtractGenericBot),
         new LoggerBot("blargbot", 134133271750639616, ExtractBlargBot),
@@ -228,6 +230,15 @@ public class LoggerCleanService
         if (embed?.Footer == null || embed.Timestamp == null ||
             !(embed.Title?.StartsWith("Message deleted in") ?? false)) return null;
         var match = _carlRegex.Match(embed.Description);
+        return match.Success ? ulong.Parse(match.Groups[1].Value) : null;
+    }
+
+    private static ulong? ExtractMaki(Message msg)
+    {
+        // Embed, Message Author Name field: "Message Deleted", footer is "Message ID: [id]"
+        var embed = msg.Embeds?.FirstOrDefault();
+        if (embed.Author?.Name == null || embed?.Footer == null || !embed.Author.Name.StartsWith("Message Deleted")) return null;
+        var match = _makiRegex.Match(embed.Footer.Text ?? "");
         return match.Success ? ulong.Parse(match.Groups[1].Value) : null;
     }
 


### PR DESCRIPTION
Heya!

I'm one of the developers for https://maki.gg.

We're currently rolling out a change to our deleted message logger that includes "Message ID: [id]" in the embed footer. We added this so PluralKit (and other similar bots) will be able to scan these logs and delete them where necessary to stop log spam :)

I believe I've managed to implement the regex & log scanning correctly - though this is my first time contributing to PK so any advice is appreciated! 

![img](https://pics.uwu.gal/u/tZ1fdd.png)
