### PR TITLE
feat: dynamically show primary command prefix

### DIFF
--- a/PluralKit.Bot/CommandMeta/CommandParseErrors.cs
+++ b/PluralKit.Bot/CommandMeta/CommandParseErrors.cs
@@ -10,26 +10,26 @@ public partial class CommandTree
 {
     private async Task PrintCommandNotFoundError(Context ctx, params Command[] potentialCommands)
     {
-        var commandListStr = CreatePotentialCommandList(potentialCommands);
+        var commandListStr = CreatePotentialCommandList(ctx.DefaultPrefix, potentialCommands);
         await ctx.Reply(
-            $"{Emojis.Error} Unknown command `pk;{ctx.FullCommand().Truncate(100)}`. Perhaps you meant to use one of the following commands?\n{commandListStr}\n\nFor a full list of possible commands, see <https://pluralkit.me/commands>.");
+            $"{Emojis.Error} Unknown command `{ctx.DefaultPrefix}{ctx.FullCommand().Truncate(100)}`. Perhaps you meant to use one of the following commands?\n{commandListStr}\n\nFor a full list of possible commands, see <https://pluralkit.me/commands>.");
     }
 
     private async Task PrintCommandExpectedError(Context ctx, params Command[] potentialCommands)
     {
-        var commandListStr = CreatePotentialCommandList(potentialCommands);
+        var commandListStr = CreatePotentialCommandList(ctx.DefaultPrefix, potentialCommands);
         await ctx.Reply(
             $"{Emojis.Error} You need to pass a command. Perhaps you meant to use one of the following commands?\n{commandListStr}\n\nFor a full list of possible commands, see <https://pluralkit.me/commands>.");
     }
 
-    private static string CreatePotentialCommandList(params Command[] potentialCommands)
+    private static string CreatePotentialCommandList(string prefix, params Command[] potentialCommands)
     {
-        return string.Join("\n", potentialCommands.Select(cmd => $"- **pk;{cmd.Usage}** - *{cmd.Description}*"));
+        return string.Join("\n", potentialCommands.Select(cmd => $"- **{prefix}{cmd.Usage}** - *{cmd.Description}*"));
     }
 
     private async Task PrintCommandList(Context ctx, string subject, params Command[] commands)
     {
-        var str = CreatePotentialCommandList(commands);
+        var str = CreatePotentialCommandList(ctx.DefaultPrefix, commands);
         await ctx.Reply(
             $"Here is a list of commands related to {subject}:",
             embed: new Embed()

--- a/PluralKit.Bot/CommandMeta/CommandTree.cs
+++ b/PluralKit.Bot/CommandMeta/CommandTree.cs
@@ -64,7 +64,7 @@ public partial class CommandTree
             else if (ctx.Match("list", "show"))
                 return ctx.Execute<ServerConfig>(LogShow, m => m.ShowLogDisabledChannels(ctx), true);
             else
-                return ctx.Reply($"{Emojis.Warn} Message logging commands have moved to `pk;serverconfig`.");
+                return ctx.Reply($"{Emojis.Warn} Message logging commands have moved to `{ctx.DefaultPrefix}serverconfig`.");
         if (ctx.Match("logclean"))
             return ctx.Execute<ServerConfig>(ServerConfigLogClean, m => m.SetLogCleanup(ctx), true);
         if (ctx.Match("blacklist", "bl"))
@@ -75,7 +75,7 @@ public partial class CommandTree
             else if (ctx.Match("list", "show"))
                 return ctx.Execute<ServerConfig>(BlacklistShow, m => m.ShowProxyBlacklisted(ctx), true);
             else
-                return ctx.Reply($"{Emojis.Warn} Blacklist commands have moved to `pk;serverconfig`.");
+                return ctx.Reply($"{Emojis.Warn} Blacklist commands have moved to `{ctx.DefaultPrefix}serverconfig`.");
         if (ctx.Match("proxy"))
             if (ctx.Match("debug"))
                 return ctx.Execute<Checks>(ProxyCheck, m => m.MessageProxyCheck(ctx));
@@ -257,7 +257,7 @@ public partial class CommandTree
                     return;
                 }
 
-                var list = CreatePotentialCommandList(SystemCommands);
+                var list = CreatePotentialCommandList(ctx.DefaultPrefix, SystemCommands);
                 await ctx.Reply($"{Emojis.Error} {await CreateSystemNotFoundError(ctx)}\n\n"
                         + $"Perhaps you meant to use one of the following commands?\n{list}");
             }
@@ -493,7 +493,7 @@ public partial class CommandTree
         {
             await ctx.Reply(
                 "Available command help targets: `system`, `member`, `group`, `switch`, `config`, `autoproxy`, `log`, `blacklist`."
-                + "\n- **pk;commands <target>** - *View commands related to a help target.*"
+                + $"\n- **{ctx.DefaultPrefix}commands <target>** - *View commands related to a help target.*"
                 + "\n\nFor the full list of commands, see the website: <https://pluralkit.me/commands>");
             return;
         }
@@ -553,7 +553,7 @@ public partial class CommandTree
         // oops, that breaks stuff! PKErrors before ctx.Execute don't actually do anything.
         // so we just emulate checking and throwing an error.
         if (ctx.System == null)
-            return ctx.Reply($"{Emojis.Error} {Errors.NoSystemError.Message}");
+            return ctx.Reply($"{Emojis.Error} {Errors.NoSystemError(ctx.DefaultPrefix).Message}");
 
         return ctx.Execute<Autoproxy>(AutoproxySet, m => m.SetAutoproxyMode(ctx));
     }
@@ -561,7 +561,7 @@ public partial class CommandTree
     private Task HandleConfigCommand(Context ctx)
     {
         if (ctx.System == null)
-            return ctx.Reply($"{Emojis.Error} {Errors.NoSystemError.Message}");
+            return ctx.Reply($"{Emojis.Error} {Errors.NoSystemError(ctx.DefaultPrefix).Message}");
 
         if (!ctx.HasNext())
             return ctx.Execute<Config>(null, m => m.ShowConfig(ctx));
@@ -600,7 +600,7 @@ public partial class CommandTree
             return ctx.Execute<Config>(null, m => m.ServerNameFormat(ctx));
 
         // todo: maybe add the list of configuration keys here?
-        return ctx.Reply($"{Emojis.Error} Could not find a setting with that name. Please see `pk;commands config` for the list of possible config settings.");
+        return ctx.Reply($"{Emojis.Error} Could not find a setting with that name. Please see `{ctx.DefaultPrefix}commands config` for the list of possible config settings.");
     }
 
     private Task HandleServerConfigCommand(Context ctx)
@@ -638,6 +638,6 @@ public partial class CommandTree
         }
 
         // todo: maybe add the list of configuration keys here?
-        return ctx.Reply($"{Emojis.Error} Could not find a setting with that name. Please see `pk;commands serverconfig` for the list of possible config settings.");
+        return ctx.Reply($"{Emojis.Error} Could not find a setting with that name. Please see `{ctx.DefaultPrefix}commands serverconfig` for the list of possible config settings.");
     }
 }

--- a/PluralKit.Bot/CommandSystem/Context/Context.cs
+++ b/PluralKit.Bot/CommandSystem/Context/Context.cs
@@ -30,7 +30,7 @@ public class Context
 
     public Context(ILifetimeScope provider, int shardId, Guild? guild, Channel channel, MessageCreateEvent message,
                                                     int commandParseOffset, PKSystem senderSystem, SystemConfig config,
-                                                    GuildConfig? guildConfig)
+                                                    GuildConfig? guildConfig, string[] prefixes)
     {
         Message = (Message)message;
         ShardId = shardId;
@@ -47,6 +47,7 @@ public class Context
         _provider = provider;
         _commandMessageService = provider.Resolve<CommandMessageService>();
         CommandPrefix = message.Content?.Substring(0, commandParseOffset);
+        DefaultPrefix = prefixes[0];
         Parameters = new Parameters(message.Content?.Substring(commandParseOffset));
         Rest = provider.Resolve<DiscordApiClient>();
         Cluster = provider.Resolve<Cluster>();
@@ -74,6 +75,7 @@ public class Context
     public DateTimeZone Zone => Config?.Zone ?? DateTimeZone.Utc;
 
     public readonly string CommandPrefix;
+    public readonly string DefaultPrefix;
     public readonly Parameters Parameters;
 
     internal readonly IDatabase Database;
@@ -115,7 +117,7 @@ public class Context
 
         if (deprecated && commandDef != null)
         {
-            await Reply($"{Emojis.Warn} Server configuration has moved to `pk;serverconfig`. The command you are trying to run is now `pk;{commandDef.Key}`.");
+            await Reply($"{Emojis.Warn} Server configuration has moved to `{DefaultPrefix}serverconfig`. The command you are trying to run is now `{DefaultPrefix}{commandDef.Key}`.");
         }
 
         try
@@ -127,7 +129,7 @@ public class Context
         }
         catch (PKSyntaxError e)
         {
-            await Reply($"{Emojis.Error} {e.Message}\n**Command usage:**\n> pk;{commandDef?.Usage}");
+            await Reply($"{Emojis.Error} {e.Message}\n**Command usage:**\n> {DefaultPrefix}{commandDef?.Usage}");
         }
         catch (PKError e)
         {

--- a/PluralKit.Bot/CommandSystem/Context/ContextChecksExt.cs
+++ b/PluralKit.Bot/CommandSystem/Context/ContextChecksExt.cs
@@ -51,21 +51,21 @@ public static class ContextChecksExt
     public static Context CheckSystem(this Context ctx)
     {
         if (ctx.System == null)
-            throw Errors.NoSystemError;
+            throw Errors.NoSystemError(ctx.DefaultPrefix);
         return ctx;
     }
 
     public static Context CheckSystem(this Context ctx, PKSystem system)
     {
         if (system == null)
-            throw Errors.NoSystemError;
+            throw Errors.NoSystemError(ctx.DefaultPrefix);
         return ctx;
     }
 
     public static Context CheckNoSystem(this Context ctx)
     {
         if (ctx.System != null)
-            throw Errors.ExistingSystemError;
+            throw Errors.ExistingSystemError(ctx.DefaultPrefix);
         return ctx;
     }
 

--- a/PluralKit.Bot/Commands/Admin.cs
+++ b/PluralKit.Bot/Commands/Admin.cs
@@ -346,7 +346,7 @@ public class Admin
 
         var existingAccount = await ctx.Repository.GetSystemByAccount(account.Id);
         if (existingAccount != null)
-            throw Errors.AccountInOtherSystem(existingAccount, ctx.Config);
+            throw Errors.AccountInOtherSystem(existingAccount, ctx.Config, ctx.DefaultPrefix);
 
         var system = await ctx.Repository.GetSystem(systemId.Value!);
         await ctx.Reply(null, await CreateEmbed(ctx, system));

--- a/PluralKit.Bot/Commands/Api.cs
+++ b/PluralKit.Bot/Commands/Api.cs
@@ -40,7 +40,7 @@ public class Api
                 new MessageRequest
                 {
                     Content = $"{Emojis.Warn} Please note that this grants access to modify (and delete!) all your system data, so keep it safe and secure."
-                            + $" If it leaks or you need a new one, you can invalidate this one with `pk;token refresh`.\n\nYour token is below:"
+                            + $" If it leaks or you need a new one, you can invalidate this one with `{ctx.DefaultPrefix}token refresh`.\n\nYour token is below:"
                 });
             await ctx.Rest.CreateMessage(dm, new MessageRequest { Content = token });
 
@@ -122,7 +122,7 @@ public class Api
         if (!ctx.HasNext(false))
         {
             if (ctx.System.WebhookUrl == null)
-                await ctx.Reply("Your system does not have a webhook URL set. Set one with `pk;system webhook <url>`!");
+                await ctx.Reply($"Your system does not have a webhook URL set. Set one with `{ctx.DefaultPrefix}system webhook <url>`!");
             else
                 await ctx.Reply($"Your system's webhook URL is <{ctx.System.WebhookUrl}>.");
             return;

--- a/PluralKit.Bot/Commands/Autoproxy.cs
+++ b/PluralKit.Bot/Commands/Autoproxy.cs
@@ -32,7 +32,7 @@ public class Autoproxy
         else if (ctx.Match("front", "fronter", "switch", "f"))
             await AutoproxyFront(ctx, settings);
         else if (ctx.Match("member"))
-            throw new PKSyntaxError("Member-mode autoproxy must target a specific member. Use the `pk;autoproxy <member>` command, where `member` is the name or ID of a member in your system.");
+            throw new PKSyntaxError($"Member-mode autoproxy must target a specific member. Use the `{ctx.DefaultPrefix}autoproxy <member>` command, where `member` is the name or ID of a member in your system.");
         else if (await ctx.MatchMember() is PKMember member)
             await AutoproxyMember(ctx, member);
         else if (!ctx.HasNext())
@@ -58,7 +58,7 @@ public class Autoproxy
     {
         if (settings.AutoproxyMode == AutoproxyMode.Latch)
         {
-            await ctx.Reply($"{Emojis.Note} Autoproxy is already set to latch mode in this server. If you want to disable autoproxying, use `pk;autoproxy off`.");
+            await ctx.Reply($"{Emojis.Note} Autoproxy is already set to latch mode in this server. If you want to disable autoproxying, use `{ctx.DefaultPrefix}autoproxy off`.");
         }
         else
         {
@@ -71,7 +71,7 @@ public class Autoproxy
     {
         if (settings.AutoproxyMode == AutoproxyMode.Front)
         {
-            await ctx.Reply($"{Emojis.Note} Autoproxy is already set to front mode in this server. If you want to disable autoproxying, use `pk;autoproxy off`.");
+            await ctx.Reply($"{Emojis.Note} Autoproxy is already set to front mode in this server. If you want to disable autoproxying, use `{ctx.DefaultPrefix}autoproxy off`.");
         }
         else
         {
@@ -92,9 +92,9 @@ public class Autoproxy
 
     private async Task<Embed> CreateAutoproxyStatusEmbed(Context ctx, AutoproxySettings settings)
     {
-        var commandList = "**pk;autoproxy latch** - Autoproxies as last-proxied member"
-                        + "\n**pk;autoproxy front** - Autoproxies as current (first) fronter"
-                        + "\n**pk;autoproxy <member>** - Autoproxies as a specific member";
+        var commandList = $"**{ctx.DefaultPrefix}autoproxy latch** - Autoproxies as last-proxied member"
+                        + $"\n**{ctx.DefaultPrefix}autoproxy front** - Autoproxies as current (first) fronter"
+                        + $"\n**{ctx.DefaultPrefix}autoproxy <member>** - Autoproxies as a specific member";
         var eb = new EmbedBuilder()
             .Title($"Current autoproxy status (for {ctx.Guild.Name.EscapeMarkdown()})");
 
@@ -124,13 +124,13 @@ public class Autoproxy
                 {
                     if (fronters.Count == 0)
                     {
-                        eb.Description("Autoproxy is currently set to **front mode** in this server, but there are currently no fronters registered. Use the `pk;switch` command to log a switch.");
+                        eb.Description($"Autoproxy is currently set to **front mode** in this server, but there are currently no fronters registered. Use the `{ctx.DefaultPrefix}switch` command to log a switch.");
                     }
                     else
                     {
                         if (relevantMember == null)
                             throw new ArgumentException("Attempted to print member autoproxy status, but the linked member ID wasn't found in the database. Should be handled appropriately.");
-                        eb.Description($"Autoproxy is currently set to **front mode** in this server. The current (first) fronter is **{relevantMember.NameFor(ctx).EscapeMarkdown()}** (`{relevantMember.DisplayHid(ctx.Config)}`). To disable, type `pk;autoproxy off`.");
+                        eb.Description($"Autoproxy is currently set to **front mode** in this server. The current (first) fronter is **{relevantMember.NameFor(ctx).EscapeMarkdown()}** (`{relevantMember.DisplayHid(ctx.Config)}`). To disable, type `{ctx.DefaultPrefix}autoproxy off`.");
                     }
 
                     break;
@@ -142,15 +142,15 @@ public class Autoproxy
                         // ideally we would set it to off in the database though...
                         eb.Description($"Autoproxy is currently **off** in this server. To enable it, use one of the following commands:\n{commandList}");
                     else
-                        eb.Description($"Autoproxy is active for member **{relevantMember.NameFor(ctx)}** (`{relevantMember.DisplayHid(ctx.Config)}`) in this server. To disable, type `pk;autoproxy off`.");
+                        eb.Description($"Autoproxy is active for member **{relevantMember.NameFor(ctx)}** (`{relevantMember.DisplayHid(ctx.Config)}`) in this server. To disable, type `{ctx.DefaultPrefix}autoproxy off`.");
 
                     break;
                 }
             case AutoproxyMode.Latch:
                 if (relevantMember == null)
-                    eb.Description("Autoproxy is currently set to **latch mode**, meaning the *last-proxied member* will be autoproxied. **No member is currently latched.** To disable, type `pk;autoproxy off`.");
+                    eb.Description($"Autoproxy is currently set to **latch mode**, meaning the *last-proxied member* will be autoproxied. **No member is currently latched.** To disable, type `{ctx.DefaultPrefix}autoproxy off`.");
                 else
-                    eb.Description($"Autoproxy is currently set to **latch mode**, meaning the *last-proxied member* will be autoproxied. The currently latched member is **{relevantMember.NameFor(ctx)}** (`{relevantMember.DisplayHid(ctx.Config)}`). To disable, type `pk;autoproxy off`.");
+                    eb.Description($"Autoproxy is currently set to **latch mode**, meaning the *last-proxied member* will be autoproxied. The currently latched member is **{relevantMember.NameFor(ctx)}** (`{relevantMember.DisplayHid(ctx.Config)}`). To disable, type `{ctx.DefaultPrefix}autoproxy off`.");
 
                 break;
 
@@ -159,7 +159,7 @@ public class Autoproxy
 
         var allowAutoproxy = await ctx.Repository.GetAutoproxyEnabled(ctx.Author.Id);
         if (!allowAutoproxy)
-            eb.Field(new Embed.Field("\u200b", $"{Emojis.Note} Autoproxy is currently **disabled** for your account (<@{ctx.Author.Id}>). To enable it, use `pk;autoproxy account enable`."));
+            eb.Field(new Embed.Field("\u200b", $"{Emojis.Note} Autoproxy is currently **disabled** for your account (<@{ctx.Author.Id}>). To enable it, use `{ctx.DefaultPrefix}autoproxy account enable`."));
 
         return eb.Build();
     }

--- a/PluralKit.Bot/Commands/Checks.cs
+++ b/PluralKit.Bot/Commands/Checks.cs
@@ -256,10 +256,10 @@ public class Checks
         // Run everything through the checks, catch the ProxyCheckFailedException, and reply with the error message.
         try
         {
-            _proxy.ShouldProxy(channel, rootChannel, msg, context);
-            _matcher.TryMatch(context, autoproxySettings, members, out var match, msg.Content, msg.Attachments.Length > 0, true, ctx.Config.CaseSensitiveProxyTags);
+            _proxy.ShouldProxy(channel, rootChannel, msg, context, ctx.DefaultPrefix);
+            _matcher.TryMatch(context, autoproxySettings, members, out var match, msg.Content, ctx.DefaultPrefix, msg.Attachments.Length > 0, true, ctx.Config.CaseSensitiveProxyTags);
 
-            var canProxy = await _proxy.CanProxy(channel, rootChannel, msg, context);
+            var canProxy = await _proxy.CanProxy(channel, rootChannel, msg, context, ctx.DefaultPrefix);
             if (canProxy != null)
             {
                 await ctx.Reply(canProxy);

--- a/PluralKit.Bot/Commands/Config.cs
+++ b/PluralKit.Bot/Commands/Config.cs
@@ -182,7 +182,7 @@ public class Config
                 eb.Description(description.ToString());
 
                 // using *large* blue diamond here since it's easier to see in the small footer
-                eb.Footer(new("\U0001f537 means this setting was changed. Type `pk;config <setting name> clear` to reset it to the default."));
+                eb.Footer(new($"\U0001f537 means this setting was changed. Type `{ctx.DefaultPrefix}config <setting name> clear` to reset it to the default."));
 
                 return Task.CompletedTask;
             }
@@ -263,7 +263,7 @@ public class Config
 
     public async Task SystemTimezone(Context ctx)
     {
-        if (ctx.System == null) throw Errors.NoSystemError;
+        if (ctx.System == null) throw Errors.NoSystemError(ctx.DefaultPrefix);
 
         if (ctx.MatchClear())
         {
@@ -277,7 +277,7 @@ public class Config
         if (zoneStr == null)
         {
             await ctx.Reply(
-                $"Your current system time zone is set to **{ctx.Config.UiTz}**. It is currently **{SystemClock.Instance.GetCurrentInstant().FormatZoned(ctx.Config.Zone)}** in that time zone. To change your system time zone, type `pk;config tz <zone>`.");
+                $"Your current system time zone is set to **{ctx.Config.UiTz}**. It is currently **{SystemClock.Instance.GetCurrentInstant().FormatZoned(ctx.Config.Zone)}** in that time zone. To change your system time zone, type `{ctx.DefaultPrefix}config tz <zone>`.");
             return;
         }
 
@@ -362,7 +362,7 @@ public class Config
 
         String Response(bool isError, bool val)
             => $"Reaction pings are {(isError ? "already" : "currently")} **{EnabledDisabled(val)}** for your system. "
-             + $"To {EnabledDisabled(!val)[..^1]} reaction pings, type `pk;config ping {EnabledDisabled(!val)[..^1]}`.";
+             + $"To {EnabledDisabled(!val)[..^1]} reaction pings, type `{ctx.DefaultPrefix}config ping {EnabledDisabled(!val)[..^1]}`.";
 
         if (!ctx.HasNext())
         {
@@ -385,8 +385,8 @@ public class Config
     {
         if (!ctx.HasNext())
         {
-            if (ctx.Config.MemberDefaultPrivate) { await ctx.Reply("Newly created members will currently have their privacy settings set to private. To change this, type `pk;config private member off`"); }
-            else { await ctx.Reply("Newly created members will currently have their privacy settings set to public. To automatically set new members' privacy settings to private, type `pk;config private member on`"); }
+            if (ctx.Config.MemberDefaultPrivate) { await ctx.Reply($"Newly created members will currently have their privacy settings set to private. To change this, type `{ctx.DefaultPrefix}config private member off`"); }
+            else { await ctx.Reply($"Newly created members will currently have their privacy settings set to public. To automatically set new members' privacy settings to private, type `{ctx.DefaultPrefix}config private member on`"); }
         }
         else
         {
@@ -409,8 +409,8 @@ public class Config
     {
         if (!ctx.HasNext())
         {
-            if (ctx.Config.GroupDefaultPrivate) { await ctx.Reply("Newly created groups will currently have their privacy settings set to private. To change this, type `pk;config private group off`"); }
-            else { await ctx.Reply("Newly created groups will currently have their privacy settings set to public. To automatically set new groups' privacy settings to private, type `pk;config private group on`"); }
+            if (ctx.Config.GroupDefaultPrivate) { await ctx.Reply($"Newly created groups will currently have their privacy settings set to private. To change this, type `{ctx.DefaultPrefix}config private group off`"); }
+            else { await ctx.Reply($"Newly created groups will currently have their privacy settings set to public. To automatically set new groups' privacy settings to private, type `{ctx.DefaultPrefix}config private group on`"); }
         }
         else
         {

--- a/PluralKit.Bot/Commands/Groups.cs
+++ b/PluralKit.Bot/Commands/Groups.cs
@@ -84,13 +84,13 @@ public class Groups
         var eb = new EmbedBuilder()
             .Description(
                 $"Your new group, **{groupName}**, has been created, with the group ID **`{newGroup.DisplayHid(ctx.Config)}`**.\nBelow are a couple of useful commands:")
-            .Field(new Embed.Field("View the group card", $"> pk;group **{reference}**"))
+            .Field(new Embed.Field("View the group card", $"> {ctx.DefaultPrefix}group **{reference}**"))
             .Field(new Embed.Field("Add members to the group",
-                $"> pk;group **{reference}** add **MemberName**\n> pk;group **{reference}** add **Member1** **Member2** **Member3** (and so on...)"))
+                $"> {ctx.DefaultPrefix}group **{reference}** add **MemberName**\n> {ctx.DefaultPrefix}group **{reference}** add **Member1** **Member2** **Member3** (and so on...)"))
             .Field(new Embed.Field("Set the description",
-                $"> pk;group **{reference}** description **This is my new group, and here is the description!**"))
+                $"> {ctx.DefaultPrefix}group **{reference}** description **This is my new group, and here is the description!**"))
             .Field(new Embed.Field("Set the group icon",
-                $"> pk;group **{reference}** icon\n*(with an image attached)*"));
+                $"> {ctx.DefaultPrefix}group **{reference}** icon\n*(with an image attached)*"));
         await ctx.Reply($"{Emojis.Success} Group created!", eb.Build());
 
         if (existingGroupCount >= Limits.WarnThreshold(groupLimit))
@@ -128,7 +128,7 @@ public class Groups
         var noDisplayNameSetMessage = "This group does not have a display name set.";
         if (ctx.System?.Id == target.System)
             noDisplayNameSetMessage +=
-                $" To set one, type `pk;group {target.Reference(ctx)} displayname <display name>`.";
+                $" To set one, type `{ctx.DefaultPrefix}group {target.Reference(ctx)} displayname <display name>`.";
 
         // No perms check, display name isn't covered by member privacy
 
@@ -165,9 +165,9 @@ public class Groups
 
             if (ctx.System?.Id == target.System)
                 eb.Description(
-                    $"To change display name, type `pk;group {reference} displayname <display name>`.\n"
-                    + $"To clear it, type `pk;group {reference} displayname -clear`.\n"
-                    + $"To print the raw display name, type `pk;group {reference} displayname -raw`.");
+                    $"To change display name, type `{ctx.DefaultPrefix}group {reference} displayname <display name>`.\n"
+                    + $"To clear it, type `{ctx.DefaultPrefix}group {reference} displayname -clear`.\n"
+                    + $"To print the raw display name, type `{ctx.DefaultPrefix}group {reference} displayname -raw`.");
 
             if (ctx.System?.Id == target.System)
                 eb.Footer(new Embed.EmbedFooter($"Using {target.DisplayName.Length}/{Limits.MaxGroupNameLength} characters."));
@@ -208,7 +208,7 @@ public class Groups
         var noDescriptionSetMessage = "This group does not have a description set.";
         if (ctx.System?.Id == target.System)
             noDescriptionSetMessage +=
-                $" To set one, type `pk;group {target.Reference(ctx)} description <description>`.";
+                $" To set one, type `{ctx.DefaultPrefix}group {target.Reference(ctx)} description <description>`.";
 
         var format = ctx.MatchFormat();
 
@@ -239,9 +239,9 @@ public class Groups
                 .Title("Group description")
                 .Description(target.Description)
                 .Field(new Embed.Field("\u200B",
-                    $"To print the description with formatting, type `pk;group {target.Reference(ctx)} description -raw`."
+                    $"To print the description with formatting, type `{ctx.DefaultPrefix}group {target.Reference(ctx)} description -raw`."
                     + (ctx.System?.Id == target.System
-                        ? $" To clear it, type `pk;group {target.Reference(ctx)} description -clear`."
+                        ? $" To clear it, type `{ctx.DefaultPrefix}group {target.Reference(ctx)} description -clear`."
                         : "")
                         + $" Using {target.Description.Length}/{Limits.MaxDescriptionLength} characters."))
                 .Build());
@@ -327,7 +327,7 @@ public class Groups
                             .Title("Group icon")
                             .Image(new Embed.EmbedImage(target.Icon.TryGetCleanCdnUrl()));
                         if (target.System == ctx.System?.Id)
-                            ebS.Description($"To clear, use `pk;group {target.Reference(ctx)} icon -clear`.");
+                            ebS.Description($"To clear, use `{ctx.DefaultPrefix}group {target.Reference(ctx)} icon -clear`.");
                         await ctx.Reply(embed: ebS.Build());
                         break;
                 }
@@ -401,7 +401,7 @@ public class Groups
                             .Title("Group banner image")
                             .Image(new Embed.EmbedImage(target.BannerImage.TryGetCleanCdnUrl()));
                         if (target.System == ctx.System?.Id)
-                            ebS.Description($"To clear, use `pk;group {target.Reference(ctx)} banner clear`.");
+                            ebS.Description($"To clear, use `{ctx.DefaultPrefix}group {target.Reference(ctx)} banner clear`.");
                         await ctx.Reply(embed: ebS.Build());
                         break;
                 }
@@ -428,7 +428,7 @@ public class Groups
         {
             if (target.Color == null)
                 await ctx.Reply(
-                    "This group does not have a color set." + (isOwnSystem ? $" To set one, type `pk;group {target.Reference(ctx)} color <color>`." : ""));
+                    "This group does not have a color set." + (isOwnSystem ? $" To set one, type `{ctx.DefaultPrefix}group {target.Reference(ctx)} color <color>`." : ""));
             else if (matchedFormat == ReplyFormat.Raw)
                 await ctx.Reply("```\n#" + target.Color + "\n```");
             else if (matchedFormat == ReplyFormat.Plaintext)
@@ -439,7 +439,7 @@ public class Groups
                     .Color(target.Color.ToDiscordColor())
                     .Thumbnail(new Embed.EmbedThumbnail($"https://fakeimg.pl/256x256/{target.Color}/?text=%20"))
                     .Description($"This group's color is **#{target.Color}**."
-                        + (isOwnSystem ? $" To clear it, type `pk;group {target.Reference(ctx)} color -clear`." : ""))
+                        + (isOwnSystem ? $" To clear it, type `{ctx.DefaultPrefix}group {target.Reference(ctx)} color -clear`." : ""))
                     .Build());
             return;
         }
@@ -531,7 +531,7 @@ public class Groups
                 .Field(new Embed.Field("Metadata (creation date)", target.MetadataPrivacy.Explanation()))
                 .Field(new Embed.Field("Visibility", target.Visibility.Explanation()))
                 .Description(
-                    $"To edit privacy settings, use the command:\n> pk;group **{target.Reference(ctx)}** privacy **<subject>** **<level>**\n\n- `subject` is one of `name`, `description`, `banner`, `icon`, `members`, `metadata`, `visibility`, or `all`\n- `level` is either `public` or `private`.")
+                    $"To edit privacy settings, use the command:\n> {ctx.DefaultPrefix}group **{target.Reference(ctx)}** privacy **<subject>** **<level>**\n\n- `subject` is one of `name`, `description`, `banner`, `icon`, `members`, `metadata`, `visibility`, or `all`\n- `level` is either `public` or `private`.")
                 .Build());
             return;
         }

--- a/PluralKit.Bot/Commands/Help.cs
+++ b/PluralKit.Bot/Commands/Help.cs
@@ -8,7 +8,7 @@ namespace PluralKit.Bot;
 public class Help
 {
     private static string Description = "PluralKit is a bot designed for plural communities on Discord, and is open for anyone to use. It allows you to register systems, maintain system information, set up message proxying, log switches, and more.\n\n" +
-                "**System recovery:** in the case of your Discord account getting lost or deleted, the PluralKit staff can help you recover your system, **only if you save the system token from `pk;token`**. See [this FAQ entry](https://pluralkit.me/faq/#can-i-recover-my-system-if-i-lose-access-to-my-discord-account) for more details.\n\n" +
+                "**System recovery:** in the case of your Discord account getting lost or deleted, the PluralKit staff can help you recover your system, **only if you save the system token from `{prefix}token`**. See [this FAQ entry](https://pluralkit.me/faq/#can-i-recover-my-system-if-i-lose-access-to-my-discord-account) for more details.\n\n" +
                 "If PluralKit is useful to you, please consider donating on [Patreon](https://patreon.com/pluralkit) or [Buy Me A Coffee](https://buymeacoffee.com/pluralkit).\n" +
                 "## Use the buttons below to see more info!";
 
@@ -48,11 +48,11 @@ public class Help
                     String.Join("\n", new[]
                     {
                         "To get started using PluralKit, try running the following commands (of course replacing the relevant names with your own):",
-                        "**1**. `pk;system new` - Create a system (if you haven't already)",
-                        "**2**. `pk;member add John` - Add a new member to your system",
-                        "**3**. `pk;member John proxy [text]` - Set up [square brackets] as proxy tags",
+                        "**1**. `{prefix}system new` - Create a system (if you haven't already)",
+                        "**2**. `{prefix}member add John` - Add a new member to your system",
+                        "**3**. `{prefix}member John proxy [text]` - Set up [square brackets] as proxy tags",
                         "**4**. You're done! You can now type [a message in brackets] and it'll be proxied appropriately.",
-                        "**5**. Optionally, you may set an avatar from the URL of an image with `pk;member John avatar [link to image]`, or from a file by typing `pk;member John avatar` and sending the message with an attached image.",
+                        "**5**. Optionally, you may set an avatar from the URL of an image with `{prefix}member John avatar [link to image]`, or from a file by typing `{prefix}member John avatar` and sending the message with an attached image.",
                         "\nSee [the Getting Started guide](https://pluralkit.me/start) for more information."
                     })
                 ),
@@ -69,7 +69,7 @@ public class Help
                         $"React with {Emojis.Error} on a proxied message to delete it (only if you sent it!)",
                         $"React with {Emojis.RedQuestion} on a proxied message to look up information about it (like who sent it)",
                         $"React with {Emojis.Bell} on a proxied message to \"ping\" the sender",
-                        "Type **`pk;invite`** to get a link to invite this bot to your own server!"
+                        "Type **`{prefix}invite`** to get a link to invite this bot to your own server!"
                     })
                 ),
             }
@@ -82,9 +82,9 @@ public class Help
                 (
                     "More information",
                     String.Join("\n", new[] {
-                        "For a full list of commands, see [the command list](https://pluralkit.me/commands), or type `pk;commands`.",
+                        "For a full list of commands, see [the command list](https://pluralkit.me/commands), or type `{prefix}commands`.",
                         "For a more in-depth explanation of message proxying, see [the documentation](https://pluralkit.me/guide#proxying).",
-                        "If you're an existing user of Tupperbox, type `pk;import` and attach a Tupperbox export file (from `tul!export`) to import your data from there.",
+                        "If you're an existing user of Tupperbox, type `{prefix}import` and attach a Tupperbox export file (from `tul!export`) to import your data from there.",
                         "We also have a [web dashboard](https://dash.pluralkit.me) to edit your system info online."
                     })
                 ),
@@ -142,11 +142,11 @@ public class Help
         => ctx.Rest.CreateMessage(ctx.Channel.Id, new MessageRequest
         {
             Content = $"{Emojis.Warn} If you cannot see the rest of this message see [the FAQ](<https://pluralkit.me/faq/#why-do-most-of-pluralkit-s-messages-look-blank-or-empty>)",
-            Embeds = new[] { helpEmbed with { Description = Help.Description } },
+            Embeds = new[] { helpEmbed with { Description = Help.Description.Replace("{prefix}", ctx.DefaultPrefix) } },
             Components = new[] { helpPageButtons(ctx.Author.Id) },
         });
 
-    public static Task ButtonClick(InteractionContext ctx)
+    public static Task ButtonClick(InteractionContext ctx, string prefix)
     {
         if (!ctx.CustomId.Contains(ctx.User.Id.ToString()))
             return ctx.Ignore();
@@ -156,7 +156,7 @@ public class Help
         if (ctx.Event.Message.Components.First().Components.Where(x => x.CustomId == ctx.CustomId).First().Style == ButtonStyle.Primary)
             return ctx.Respond(InteractionResponse.ResponseType.UpdateMessage, new()
             {
-                Embeds = new[] { helpEmbed with { Description = Help.Description } },
+                Embeds = new[] { helpEmbed with { Description = Help.Description.Replace("{prefix}", prefix) } },
                 Components = new[] { buttons }
             });
 
@@ -164,7 +164,8 @@ public class Help
 
         return ctx.Respond(InteractionResponse.ResponseType.UpdateMessage, new()
         {
-            Embeds = new[] { helpEmbed with { Fields = helpEmbedPages.GetValueOrDefault(ctx.CustomId.Split("-")[2]) } },
+            Embeds = new[] { helpEmbed with { Fields = helpEmbedPages.GetValueOrDefault(ctx.CustomId.Split("-")[2]).Select((item, index) =>
+                                                    new Embed.Field(item.Name.Replace("{prefix}", prefix), item.Value.Replace("{prefix}", prefix))).ToArray() } },
             Components = new[] { buttons }
         });
     }

--- a/PluralKit.Bot/Commands/ImportExport.cs
+++ b/PluralKit.Bot/Commands/ImportExport.cs
@@ -99,11 +99,11 @@ public class ImportExport
             else if (ctx.System == null)
                 // We didn't have a system prior to importing, so give them the new system's ID
                 await ctx.Reply(
-                    $"{Emojis.Success} PluralKit has created a system for you based on the given file. Your system ID is `{result.CreatedSystem}`. Type `pk;system` for more information.");
+                    $"{Emojis.Success} PluralKit has created a system for you based on the given file. Your system ID is `{result.CreatedSystem}`. Type `{ctx.DefaultPrefix}system` for more information.");
             else
                 // We already had a system, so show them what changed
                 await ctx.Reply(
-                    $"{Emojis.Success} Updated {result.Modified} members, created {result.Added} members. Type `pk;system list` to check!");
+                    $"{Emojis.Success} Updated {result.Modified} members, created {result.Added} members. Type `{ctx.DefaultPrefix}system list` to check!");
         });
     }
 

--- a/PluralKit.Bot/Commands/Member.cs
+++ b/PluralKit.Bot/Commands/Member.cs
@@ -29,7 +29,7 @@ public class Member
 
     public async Task NewMember(Context ctx)
     {
-        if (ctx.System == null) throw Errors.NoSystemError;
+        if (ctx.System == null) throw Errors.NoSystemError(ctx.DefaultPrefix);
         var memberName = ctx.RemainderOrNull() ?? throw new PKSyntaxError("You must pass a member name.");
 
         // Hard name length cap
@@ -106,7 +106,7 @@ public class Member
         if (await ctx.Database.Execute(conn => conn.QuerySingleAsync<bool>("select has_private_members(@System)",
                 new { System = ctx.System.Id })) && !ctx.Config.MemberDefaultPrivate) //if has private members
             await ctx.Reply(
-                $"{Emojis.Warn} This member is currently **public**. To change this, use `pk;member {member.DisplayHid(ctx.Config)} private`.");
+                $"{Emojis.Warn} This member is currently **public**. To change this, use `{ctx.DefaultPrefix}member {member.DisplayHid(ctx.Config)} private`.");
         if (avatarArg != null)
             if (imageMatchError == null)
                 await ctx.Reply(

--- a/PluralKit.Bot/Commands/MemberAvatar.cs
+++ b/PluralKit.Bot/Commands/MemberAvatar.cs
@@ -32,7 +32,7 @@ public class MemberAvatar
         {
             if (mgs?.AvatarUrl != null)
                 await ctx.Reply(
-                    $"{Emojis.Success} Member proxy avatar cleared. Note that this member has a server-specific avatar set here, type `pk;member {target.Reference(ctx)} serveravatar clear` if you wish to clear that too.");
+                    $"{Emojis.Success} Member proxy avatar cleared. Note that this member has a server-specific avatar set here, type `{ctx.DefaultPrefix}member {target.Reference(ctx)} serveravatar clear` if you wish to clear that too.");
             else
                 await ctx.Reply($"{Emojis.Success} Member proxy avatar cleared. This member will now use the main avatar for proxied messages.");
         }
@@ -40,7 +40,7 @@ public class MemberAvatar
         {
             if (mgs?.AvatarUrl != null)
                 await ctx.Reply(
-                    $"{Emojis.Success} Member avatar cleared. Note that this member has a server-specific avatar set here, type `pk;member {target.Reference(ctx)} serveravatar clear` if you wish to clear that too.");
+                    $"{Emojis.Success} Member avatar cleared. Note that this member has a server-specific avatar set here, type `{ctx.DefaultPrefix}member {target.Reference(ctx)} serveravatar clear` if you wish to clear that too.");
             else
                 await ctx.Reply($"{Emojis.Success} Member avatar cleared.");
         }
@@ -75,11 +75,11 @@ public class MemberAvatar
 
             if (location == MemberAvatarLocation.MemberWebhook)
                 throw new PKError(
-                    $"This member does not have a proxy avatar set. Type `pk;member {target.Reference(ctx)} avatar` to see their global avatar.");
+                    $"This member does not have a proxy avatar set. Type `{ctx.DefaultPrefix}member {target.Reference(ctx)} avatar` to see their global avatar.");
 
             if (location == MemberAvatarLocation.Server)
                 throw new PKError(
-                    $"This member does not have a server avatar set. Type `pk;member {target.Reference(ctx)} avatar` to see their global avatar.");
+                    $"This member does not have a server avatar set. Type `{ctx.DefaultPrefix}member {target.Reference(ctx)} avatar` to see their global avatar.");
         }
 
         var field = location.Name();
@@ -104,7 +104,7 @@ public class MemberAvatar
                 .Title($"{target.NameFor(ctx)}'s {field}")
                 .Image(new Embed.EmbedImage(currentValue?.TryGetCleanCdnUrl()));
             if (target.System == ctx.System?.Id)
-                eb.Description($"To clear, use `pk;member {target.Reference(ctx)} {location.Command()} clear`.");
+                eb.Description($"To clear, use `{ctx.DefaultPrefix}member {target.Reference(ctx)} {location.Command()} clear`.");
             await ctx.Reply(embed: eb.Build());
         }
         else throw new PKError("Format Not Recognized");

--- a/PluralKit.Bot/Commands/MemberEdit.cs
+++ b/PluralKit.Bot/Commands/MemberEdit.cs
@@ -68,7 +68,7 @@ public class MemberEdit
         var noDescriptionSetMessage = "This member does not have a description set.";
         if (ctx.System?.Id == target.System)
             noDescriptionSetMessage +=
-                $" To set one, type `pk;member {target.Reference(ctx)} description <description>`.";
+                $" To set one, type `{ctx.DefaultPrefix}member {target.Reference(ctx)} description <description>`.";
 
         var format = ctx.MatchFormat();
 
@@ -99,9 +99,9 @@ public class MemberEdit
                 .Title("Member description")
                 .Description(target.Description)
                 .Field(new Embed.Field("\u200B",
-                    $"To print the description with formatting, type `pk;member {target.Reference(ctx)} description -raw`."
+                    $"To print the description with formatting, type `{ctx.DefaultPrefix}member {target.Reference(ctx)} description -raw`."
                     + (ctx.System?.Id == target.System
-                        ? $" To clear it, type `pk;member {target.Reference(ctx)} description -clear`."
+                        ? $" To clear it, type `{ctx.DefaultPrefix}member {target.Reference(ctx)} description -clear`."
                         : "")
                     + $" Using {target.Description.Length}/{Limits.MaxDescriptionLength} characters."))
                 .Build());
@@ -133,7 +133,7 @@ public class MemberEdit
     {
         var noPronounsSetMessage = "This member does not have pronouns set.";
         if (ctx.System?.Id == target.System)
-            noPronounsSetMessage += $" To set some, type `pk;member {target.Reference(ctx)} pronouns <pronouns>`.";
+            noPronounsSetMessage += $" To set some, type `{ctx.DefaultPrefix}member {target.Reference(ctx)} pronouns <pronouns>`.";
 
         ctx.CheckSystemPrivacy(target.System, target.PronounPrivacy);
 
@@ -163,9 +163,9 @@ public class MemberEdit
         if (!ctx.HasNext(false))
         {
             await ctx.Reply(
-                $"**{target.NameFor(ctx)}**'s pronouns are **{target.Pronouns}**.\nTo print the pronouns with formatting, type `pk;member {target.Reference(ctx)} pronouns -raw`."
+                $"**{target.NameFor(ctx)}**'s pronouns are **{target.Pronouns}**.\nTo print the pronouns with formatting, type `{ctx.DefaultPrefix}member {target.Reference(ctx)} pronouns -raw`."
                 + (ctx.System?.Id == target.System
-                    ? $" To clear them, type `pk;member {target.Reference(ctx)} pronouns -clear`."
+                    ? $" To clear them, type `{ctx.DefaultPrefix}member {target.Reference(ctx)} pronouns -clear`."
                     : "")
                 + $" Using {target.Pronouns.Length}/{Limits.MaxPronounsLength} characters.");
             return;
@@ -246,7 +246,7 @@ public class MemberEdit
                             .Title($"{target.NameFor(ctx)}'s banner image")
                             .Image(new Embed.EmbedImage(target.BannerImage.TryGetCleanCdnUrl()));
                         if (target.System == ctx.System?.Id)
-                            ebS.Description($"To clear, use `pk;member {target.Reference(ctx)} banner clear`.");
+                            ebS.Description($"To clear, use `{ctx.DefaultPrefix}member {target.Reference(ctx)} banner clear`.");
                         await ctx.Reply(embed: ebS.Build());
                         break;
                 }
@@ -273,7 +273,7 @@ public class MemberEdit
         {
             if (target.Color == null)
                 await ctx.Reply(
-                    "This member does not have a color set." + (isOwnSystem ? $" To set one, type `pk;member {target.Reference(ctx)} color <color>`." : ""));
+                    "This member does not have a color set." + (isOwnSystem ? $" To set one, type `{ctx.DefaultPrefix}member {target.Reference(ctx)} color <color>`." : ""));
             else if (matchedFormat == ReplyFormat.Raw)
                 await ctx.Reply("```\n#" + target.Color + "\n```");
             else if (matchedFormat == ReplyFormat.Plaintext)
@@ -284,7 +284,7 @@ public class MemberEdit
                     .Color(target.Color.ToDiscordColor())
                     .Thumbnail(new Embed.EmbedThumbnail($"https://fakeimg.pl/256x256/{target.Color}/?text=%20"))
                     .Description($"This member's color is **#{target.Color}**."
-                        + (isOwnSystem ? $" To clear it, type `pk;member {target.Reference(ctx)} color -clear`." : ""))
+                        + (isOwnSystem ? $" To clear it, type `{ctx.DefaultPrefix}member {target.Reference(ctx)} color -clear`." : ""))
                     .Build());
             return;
         }
@@ -333,12 +333,12 @@ public class MemberEdit
             if (target.Birthday == null)
                 await ctx.Reply("This member does not have a birthdate set."
                                 + (ctx.System?.Id == target.System
-                                    ? $" To set one, type `pk;member {target.Reference(ctx)} birthdate <birthdate>`."
+                                    ? $" To set one, type `{ctx.DefaultPrefix}member {target.Reference(ctx)} birthdate <birthdate>`."
                                     : ""));
             else
                 await ctx.Reply($"This member's birthdate is **{target.BirthdayString}**."
                                 + (ctx.System?.Id == target.System
-                                    ? $" To clear it, type `pk;member {target.Reference(ctx)} birthdate -clear`."
+                                    ? $" To clear it, type `{ctx.DefaultPrefix}member {target.Reference(ctx)} birthdate -clear`."
                                     : ""));
         }
         else
@@ -420,7 +420,7 @@ public class MemberEdit
         var noDisplayNameSetMessage = "This member does not have a display name set.";
         if (ctx.System?.Id == target.System)
             noDisplayNameSetMessage +=
-                $" To set one, type `pk;member {target.Reference(ctx)} displayname <display name>`.";
+                $" To set one, type `{ctx.DefaultPrefix}member {target.Reference(ctx)} displayname <display name>`.";
 
         // No perms check, display name isn't covered by member privacy
 
@@ -453,9 +453,9 @@ public class MemberEdit
             var reference = target.Reference(ctx);
             if (ctx.System?.Id == target.System)
                 eb.Description(
-                    $"To change display name, type `pk;member {reference} displayname <display name>`.\n"
-                    + $"To clear it, type `pk;member {reference} displayname -clear`.\n"
-                    + $"To print the raw display name, type `pk;member {reference} displayname -raw`.");
+                    $"To change display name, type `{ctx.DefaultPrefix}member {reference} displayname <display name>`.\n"
+                    + $"To clear it, type `{ctx.DefaultPrefix}member {reference} displayname -clear`.\n"
+                    + $"To print the raw display name, type `{ctx.DefaultPrefix}member {reference} displayname -raw`.");
             await ctx.Reply(embed: eb.Build());
             return;
         }
@@ -495,7 +495,7 @@ public class MemberEdit
         var noServerNameSetMessage = "This member does not have a server name set.";
         if (ctx.System?.Id == target.System)
             noServerNameSetMessage +=
-                $" To set one, type `pk;member {target.Reference(ctx)} servername <server name>`.";
+                $" To set one, type `{ctx.DefaultPrefix}member {target.Reference(ctx)} servername <server name>`.";
 
         // No perms check, display name isn't covered by member privacy
         var memberGuildConfig = await ctx.Repository.GetMemberGuild(ctx.Guild.Id, target.Id);
@@ -529,7 +529,7 @@ public class MemberEdit
             var reference = target.Reference(ctx);
             if (ctx.System?.Id == target.System)
                 eb.Description(
-                    $"To change server name, type `pk;member {reference} servername <server name>`.\nTo clear it, type `pk;member {reference} servername -clear`.\nTo print the raw server name, type `pk;member {reference} servername -raw`.");
+                    $"To change server name, type `{ctx.DefaultPrefix}member {reference} servername <server name>`.\nTo clear it, type `{ctx.DefaultPrefix}member {reference} servername -clear`.\nTo print the raw server name, type `{ctx.DefaultPrefix}member {reference} servername -raw`.");
             await ctx.Reply(embed: eb.Build());
             return;
         }
@@ -591,9 +591,9 @@ public class MemberEdit
                 keepProxyStatusMessage += "This member has keepproxy **disabled**. Proxy tags will **not** be included in the resulting message when proxying.";
 
             if (memberGuildConfig != null && memberGuildConfig.KeepProxy.HasValue && memberGuildConfig.KeepProxy.Value)
-                keepProxyStatusMessage += $"\n{Emojis.Warn} This member has keepproxy **enabled in this server**, which means proxy tags will **always** be included when proxying in this server, regardless of the global keepproxy. To clear this setting in this server, type `pk;m <member> serverkeepproxy clear`.";
+                keepProxyStatusMessage += $"\n{Emojis.Warn} This member has keepproxy **enabled in this server**, which means proxy tags will **always** be included when proxying in this server, regardless of the global keepproxy. To clear this setting in this server, type `{ctx.DefaultPrefix}m <member> serverkeepproxy clear`.";
             else if (memberGuildConfig != null && memberGuildConfig.KeepProxy.HasValue && !memberGuildConfig.KeepProxy.Value)
-                keepProxyStatusMessage += $"\n{Emojis.Warn} This member has keepproxy **disabled in this server**, which means proxy tags will **never** be included when proxying in this server, regardless of the global keepproxy. To clear this setting in this server, type `pk;m <member> serverkeepproxy clear`.";
+                keepProxyStatusMessage += $"\n{Emojis.Warn} This member has keepproxy **disabled in this server**, which means proxy tags will **never** be included when proxying in this server, regardless of the global keepproxy. To clear this setting in this server, type `{ctx.DefaultPrefix}m <member> serverkeepproxy clear`.";
 
             await ctx.Reply(keepProxyStatusMessage);
             return;
@@ -612,9 +612,9 @@ public class MemberEdit
             keepProxyUpdateMessage += $"{Emojis.Success} this member now has keepproxy **disabled**. Member proxy tags will **not** be included in the resulting message when proxying.";
 
         if (memberGuildConfig != null && memberGuildConfig.KeepProxy.HasValue && memberGuildConfig.KeepProxy.Value)
-            keepProxyUpdateMessage += $"\n{Emojis.Warn} This member has keepproxy **enabled in this server**, which means proxy tags will **always** be included when proxying in this server, regardless of the global keepproxy. To clear this setting in this server, type `pk;m <member> serverkeepproxy clear`.";
+            keepProxyUpdateMessage += $"\n{Emojis.Warn} This member has keepproxy **enabled in this server**, which means proxy tags will **always** be included when proxying in this server, regardless of the global keepproxy. To clear this setting in this server, type `{ctx.DefaultPrefix}m <member> serverkeepproxy clear`.";
         else if (memberGuildConfig != null && memberGuildConfig.KeepProxy.HasValue && !memberGuildConfig.KeepProxy.Value)
-            keepProxyUpdateMessage += $"\n{Emojis.Warn} This member has keepproxy **disabled in this server**, which means proxy tags will **never** be included when proxying in this server, regardless of the global keepproxy. To clear this setting in this server, type `pk;m <member> serverkeepproxy clear`.";
+            keepProxyUpdateMessage += $"\n{Emojis.Warn} This member has keepproxy **disabled in this server**, which means proxy tags will **never** be included when proxying in this server, regardless of the global keepproxy. To clear this setting in this server, type `{ctx.DefaultPrefix}m <member> serverkeepproxy clear`.";
 
         await ctx.Reply(keepProxyUpdateMessage);
     }
@@ -648,10 +648,10 @@ public class MemberEdit
             if (memberGuildConfig.KeepProxy.HasValue)
                 if (memberGuildConfig.KeepProxy.Value)
                     await ctx.Reply(
-                        "This member has keepproxy **enabled** in the current server, which means proxy tags will be **included** in the resulting message when proxying. To clear this setting in this server, type `pk;m <member> serverkeepproxy clear`.");
+                        $"This member has keepproxy **enabled** in the current server, which means proxy tags will be **included** in the resulting message when proxying. To clear this setting in this server, type `{ctx.DefaultPrefix}m <member> serverkeepproxy clear`.");
                 else
                     await ctx.Reply(
-                        "This member has keepproxy **disabled** in the current server, which means proxy tags will **not** be included in the resulting message when proxying. To clear this setting in this server, type `pk;m <member> serverkeepproxy clear`.");
+                        $"This member has keepproxy **disabled** in the current server, which means proxy tags will **not** be included in the resulting message when proxying. To clear this setting in this server, type `{ctx.DefaultPrefix}m <member> serverkeepproxy clear`.");
             else
             {
                 var noServerKeepProxySetMessage = "This member does not have a server keepproxy override set.";
@@ -671,10 +671,10 @@ public class MemberEdit
         if (newValue.HasValue)
             if (newValue.Value)
                 await ctx.Reply(
-                    $"{Emojis.Success} Member proxy tags will now be **included** in the resulting message when proxying **in the current server**. To clear this setting in this server, type `pk;m <member> serverkeepproxy clear`.");
+                    $"{Emojis.Success} Member proxy tags will now be **included** in the resulting message when proxying **in the current server**. To clear this setting in this server, type `{ctx.DefaultPrefix}m <member> serverkeepproxy clear`.");
             else
                 await ctx.Reply(
-                    $"{Emojis.Success} Member proxy tags will now **not** be included in the resulting message when proxying **in the current server**. To clear this setting in this server, type `pk;m <member> serverkeepproxy clear`.");
+                    $"{Emojis.Success} Member proxy tags will now **not** be included in the resulting message when proxying **in the current server**. To clear this setting in this server, type `{ctx.DefaultPrefix}m <member> serverkeepproxy clear`.");
         else
         {
             var serverKeepProxyClearedMessage = $"{Emojis.Success} Cleared server keepproxy settings for this member.";
@@ -731,7 +731,7 @@ public class MemberEdit
 
     public async Task MemberAutoproxy(Context ctx, PKMember target)
     {
-        if (ctx.System == null) throw Errors.NoSystemError;
+        if (ctx.System == null) throw Errors.NoSystemError(ctx.DefaultPrefix);
         if (target.System != ctx.System.Id) throw Errors.NotOwnMemberError;
 
         if (!ctx.HasNext())
@@ -777,7 +777,7 @@ public class MemberEdit
                     target.MetadataPrivacy.Explanation()))
                 .Field(new Embed.Field("Visibility", target.MemberVisibility.Explanation()))
                 .Description(
-                    "To edit privacy settings, use the command:\n`pk;member <member> privacy <subject> <level>`\n\n- `subject` is one of `name`, `description`, `banner`, `avatar`, `birthday`, `pronouns`, `proxies`, `metadata`, `visibility`, or `all`\n- `level` is either `public` or `private`.")
+                    $"To edit privacy settings, use the command:\n`{ctx.DefaultPrefix}member <member> privacy <subject> <level>`\n\n- `subject` is one of `name`, `description`, `banner`, `avatar`, `birthday`, `pronouns`, `proxies`, `metadata`, `visibility`, or `all`\n- `level` is either `public` or `private`.")
                 .Build());
             return;
         }
@@ -872,7 +872,7 @@ public class MemberEdit
             if (subject == MemberPrivacySubject.Avatar && level == PrivacyLevel.Private &&
                 guildSettings?.AvatarUrl == null)
                 await ctx.Reply(
-                    $"{Emojis.Warn} This member does not have a server avatar set, so *proxying* will **still show the member avatar**. If you want to hide your avatar when proxying here, set a server avatar: `pk;member {target.Reference(ctx)} serveravatar`");
+                    $"{Emojis.Warn} This member does not have a server avatar set, so *proxying* will **still show the member avatar**. If you want to hide your avatar when proxying here, set a server avatar: `{ctx.DefaultPrefix}member {target.Reference(ctx)} serveravatar`");
         }
 
         if (ctx.Match("all") || newValueFromCommand != null)

--- a/PluralKit.Bot/Commands/Message.cs
+++ b/PluralKit.Bot/Commands/Message.cs
@@ -80,7 +80,7 @@ public class ProxiedMessage
 
         try
         {
-            await _proxy.ExecuteReproxy(ctx.Message, msg, members, match);
+            await _proxy.ExecuteReproxy(ctx.Message, msg, members, match, ctx.DefaultPrefix);
 
             if (ctx.Guild == null)
                 await _rest.CreateReaction(ctx.Channel.Id, ctx.Message.Id, new Emoji { Name = Emojis.Success });

--- a/PluralKit.Bot/Commands/Random.cs
+++ b/PluralKit.Bot/Commands/Random.cs
@@ -18,7 +18,7 @@ public class Random
     public async Task Member(Context ctx, PKSystem target)
     {
         if (target == null)
-            throw Errors.NoSystemError;
+            throw Errors.NoSystemError(ctx.DefaultPrefix);
 
         ctx.CheckSystemPrivacy(target.Id, target.MemberListPrivacy);
 
@@ -43,7 +43,7 @@ public class Random
     public async Task Group(Context ctx, PKSystem target)
     {
         if (target == null)
-            throw Errors.NoSystemError;
+            throw Errors.NoSystemError(ctx.DefaultPrefix);
 
         ctx.CheckSystemPrivacy(target.Id, target.GroupListPrivacy);
 

--- a/PluralKit.Bot/Commands/ServerConfig.cs
+++ b/PluralKit.Bot/Commands/ServerConfig.cs
@@ -63,7 +63,7 @@ public class ServerConfig
             "none"
         ));
 
-        string ChannelListMessage(int count, string cmd) => $"{count} channels, use `pk;scfg {cmd}` to view/update";
+        string ChannelListMessage(int count, string cmd) => $"{count} channels, use `{ctx.DefaultPrefix}scfg {cmd}` to view/update";
 
         items.Add(new(
             "log blacklist",
@@ -105,7 +105,7 @@ public class ServerConfig
                 eb.Description(description.ToString());
 
                 // using *large* blue diamond here since it's easier to see in the small footer
-                eb.Footer(new("\U0001f537 means this setting was changed. Type `pk;serverconfig <setting name> clear` to reset it to the default."));
+                eb.Footer(new($"\U0001f537 means this setting was changed. Type `{ctx.DefaultPrefix}serverconfig <setting name> clear` to reset it to the default."));
 
                 return Task.CompletedTask;
             }
@@ -188,7 +188,7 @@ public class ServerConfig
         await ctx.Reply(
             $"{Emojis.Success} Message logging for the given channels {(enable ? "enabled" : "disabled")}." +
             (logChannel == null
-                ? $"\n{Emojis.Warn} Please note that no logging channel is set, so there is nowhere to log messages to. You can set a logging channel using `pk;serverconfig log channel #your-log-channel`."
+                ? $"\n{Emojis.Warn} Please note that no logging channel is set, so there is nowhere to log messages to. You can set a logging channel using `{ctx.DefaultPrefix}serverconfig log channel #your-log-channel`."
                 : ""));
     }
 
@@ -360,7 +360,7 @@ public class ServerConfig
         await ctx.Reply(
             $"{Emojis.Success} Channels {(shouldAdd ? "added to" : "removed from")} the logging blacklist." +
             (guild.LogChannel == null
-                ? $"\n{Emojis.Warn} Please note that no logging channel is set, so there is nowhere to log messages to. You can set a logging channel using `pk;serverconfig log channel #your-log-channel`."
+                ? $"\n{Emojis.Warn} Please note that no logging channel is set, so there is nowhere to log messages to. You can set a logging channel using `{ctx.DefaultPrefix}serverconfig log channel #your-log-channel`."
                 : ""));
     }
 
@@ -385,10 +385,10 @@ public class ServerConfig
         {
             if (ctx.GuildConfig!.LogCleanupEnabled)
                 eb.Description(
-                    "Log cleanup is currently **on** for this server. To disable it, type `pk;serverconfig logclean off`.");
+                    $"Log cleanup is currently **on** for this server. To disable it, type `{ctx.DefaultPrefix}serverconfig logclean off`.");
             else
                 eb.Description(
-                    "Log cleanup is currently **off** for this server. To enable it, type `pk;serverconfig logclean on`.");
+                    $"Log cleanup is currently **off** for this server. To enable it, type `{ctx.DefaultPrefix}serverconfig logclean on`.");
             await ctx.Reply(embed: eb.Build());
             return;
         }

--- a/PluralKit.Bot/Commands/System.cs
+++ b/PluralKit.Bot/Commands/System.cs
@@ -16,7 +16,7 @@ public class System
 
     public async Task Query(Context ctx, PKSystem system)
     {
-        if (system == null) throw Errors.NoSystemError;
+        if (system == null) throw Errors.NoSystemError(ctx.DefaultPrefix);
 
         await ctx.Reply(embed: await _embeds.CreateSystemEmbed(ctx, system, ctx.LookupContextFor(system.Id)));
     }
@@ -37,16 +37,16 @@ public class System
                 $"{Emojis.Success} Your system has been created.")
             .Field(new Embed.Field("Getting Started",
                 "New to PK? Check out our Getting Started guide on setting up members and proxies: https://pluralkit.me/start\n" +
-                "Otherwise, type `pk;system` to view your system and `pk;system help` for more information about commands you can use."))
+                $"Otherwise, type `{ctx.DefaultPrefix}system` to view your system and `{ctx.DefaultPrefix}system help` for more information about commands you can use."))
             .Field(new Embed.Field($"{Emojis.Warn} Notice {Emojis.Warn}", "PluralKit is a bot meant to help you share information about your system. " +
                 "Member descriptions are meant to be the equivalent to a Discord About Me. Because of this, any info you put in PK is **public by default**.\n" +
                 "Note that this does **not** include message content, only member fields. For more information, check out " +
                 "[the privacy section of the user guide](https://pluralkit.me/guide/#privacy). "))
             .Field(new Embed.Field("System Recovery", "In the case of your Discord account getting lost or deleted, the PluralKit staff can help you recover your system. " +
                 "In order to do so, we will need your **PluralKit token**. This is the *only* way you can prove ownership so we can help you recover your system. " +
-                "To get it, run `pk;token` and then store it in a safe place.\n\n" +
+                $"To get it, run `{ctx.DefaultPrefix}token` and then store it in a safe place.\n\n" +
                 "Keep your token safe, if other people get access to it they can also use it to access your system. " +
-                "If your token is ever compromised run `pk;token refresh` to invalidate the old token and get a new one."))
+                $"If your token is ever compromised run `{ctx.DefaultPrefix}token refresh` to invalidate the old token and get a new one."))
             .Field(new Embed.Field("Questions?",
                 "Please join the PK server https://discord.gg/PczBt78 if you have any questions, we're happy to help"));
         await ctx.Reply($"{Emojis.Warn} If you cannot see the rest of this message see [the FAQ](<https://pluralkit.me/faq/#why-do-most-of-pluralkit-s-messages-look-blank-or-empty>)", eb.Build());
@@ -56,7 +56,7 @@ public class System
     public async Task DisplayId(Context ctx, PKSystem target)
     {
         if (target == null)
-            throw Errors.NoSystemError;
+            throw Errors.NoSystemError(ctx.DefaultPrefix);
 
         await ctx.Reply(target.DisplayHid(ctx.Config));
     }

--- a/PluralKit.Bot/Commands/SystemEdit.cs
+++ b/PluralKit.Bot/Commands/SystemEdit.cs
@@ -35,7 +35,7 @@ public class SystemEdit
 
         var noNameSetMessage = $"{(isOwnSystem ? "Your" : "This")} system does not have a name set.";
         if (isOwnSystem)
-            noNameSetMessage += " Type `pk;system name <name>` to set one.";
+            noNameSetMessage += $" Type `{ctx.DefaultPrefix}system name <name>` to set one.";
 
         var format = ctx.MatchFormat();
 
@@ -64,7 +64,7 @@ public class SystemEdit
         {
             await ctx.Reply(
                 $"{(isOwnSystem ? "Your" : "This")} system's name is currently **{target.Name}**."
-                + (isOwnSystem ? " Type `pk;system name -clear` to clear it." : "")
+                + (isOwnSystem ? $" Type `{ctx.DefaultPrefix}system name -clear` to clear it." : "")
                 + $" Using {target.Name.Length}/{Limits.MaxSystemNameLength} characters.");
             return;
         }
@@ -98,7 +98,7 @@ public class SystemEdit
 
         var noNameSetMessage = $"{(isOwnSystem ? "Your" : "This")} system does not have a name specific to this server.";
         if (isOwnSystem)
-            noNameSetMessage += " Type `pk;system servername <name>` to set one.";
+            noNameSetMessage += $" Type `{ctx.DefaultPrefix}system servername <name>` to set one.";
 
         var settings = await ctx.Repository.GetSystemGuild(ctx.Guild.Id, target.Id);
 
@@ -129,7 +129,7 @@ public class SystemEdit
         {
             await ctx.Reply(
                 $"{(isOwnSystem ? "Your" : "This")} system's name for this server is currently **{settings.DisplayName}**."
-                + (isOwnSystem ? " Type `pk;system servername -clear` to clear it." : "")
+                + (isOwnSystem ? $" Type `{ctx.DefaultPrefix}system servername -clear` to clear it." : "")
                 + $" Using {settings.DisplayName.Length}/{Limits.MaxSystemNameLength} characters.");
             return;
         }
@@ -163,7 +163,7 @@ public class SystemEdit
 
         var noDescriptionSetMessage = "This system does not have a description set.";
         if (isOwnSystem)
-            noDescriptionSetMessage += " To set one, type `pk;s description <description>`.";
+            noDescriptionSetMessage += $" To set one, type `{ctx.DefaultPrefix}s description <description>`.";
 
         var format = ctx.MatchFormat();
 
@@ -194,8 +194,8 @@ public class SystemEdit
                 .Title("System description")
                 .Description(target.Description)
                 .Footer(new Embed.EmbedFooter(
-                    "To print the description with formatting, type `pk;s description -raw`."
-                        + (isOwnSystem ? " To clear it, type `pk;s description -clear`. To change it, type `pk;s description <new description>`." : "")
+                    $"To print the description with formatting, type `{ctx.DefaultPrefix}s description -raw`."
+                        + (isOwnSystem ? $" To clear it, type `{ctx.DefaultPrefix}s description -clear`. To change it, type `{ctx.DefaultPrefix}s description <new description>`." : "")
                         + $" Using {target.Description.Length}/{Limits.MaxDescriptionLength} characters."))
                 .Build());
             return;
@@ -231,7 +231,7 @@ public class SystemEdit
         {
             if (target.Color == null)
                 await ctx.Reply(
-                    "This system does not have a color set." + (isOwnSystem ? " To set one, type `pk;system color <color>`." : ""));
+                    "This system does not have a color set." + (isOwnSystem ? $" To set one, type `{ctx.DefaultPrefix}system color <color>`." : ""));
             else if (matchedFormat == ReplyFormat.Raw)
                 await ctx.Reply("```\n#" + target.Color + "\n```");
             else if (matchedFormat == ReplyFormat.Plaintext)
@@ -242,7 +242,7 @@ public class SystemEdit
                     .Color(target.Color.ToDiscordColor())
                     .Thumbnail(new Embed.EmbedThumbnail($"https://fakeimg.pl/256x256/{target.Color}/?text=%20"))
                     .Description(
-                        $"This system's color is **#{target.Color}**." + (isOwnSystem ? " To clear it, type `pk;s color -clear`." : ""))
+                        $"This system's color is **#{target.Color}**." + (isOwnSystem ? $" To clear it, type `{ctx.DefaultPrefix}s color -clear`." : ""))
                     .Build());
             return;
         }
@@ -278,7 +278,7 @@ public class SystemEdit
         var isOwnSystem = ctx.System?.Id == target.Id;
 
         var noTagSetMessage = isOwnSystem
-            ? "You currently have no system tag set. To set one, type `pk;s tag <tag>`."
+            ? $"You currently have no system tag set. To set one, type `{ctx.DefaultPrefix}s tag <tag>`."
             : "This system currently has no system tag set.";
 
         var format = ctx.MatchFormat();
@@ -307,7 +307,7 @@ public class SystemEdit
         if (!ctx.HasNext(false))
         {
             await ctx.Reply($"{(isOwnSystem ? "Your" : "This system's")} current system tag is {target.Tag.AsCode()}."
-                + (isOwnSystem ? "To change it, type `pk;s tag <tag>`. To clear it, type `pk;s tag -clear`." : ""));
+                + (isOwnSystem ? $"To change it, type `{ctx.DefaultPrefix}s tag <tag>`. To clear it, type `{ctx.DefaultPrefix}s tag -clear`." : ""));
             return;
         }
 
@@ -338,7 +338,7 @@ public class SystemEdit
         ctx.CheckSystem().CheckOwnSystem(target).CheckGuildContext();
 
         var setDisabledWarning =
-            $"{Emojis.Warn} Your system tag is currently **disabled** in this server. No tag will be applied when proxying.\nTo re-enable the system tag in the current server, type `pk;s servertag -enable`.";
+            $"{Emojis.Warn} Your system tag is currently **disabled** in this server. No tag will be applied when proxying.\nTo re-enable the system tag in the current server, type `{ctx.DefaultPrefix}s servertag -enable`.";
 
         var settings = await ctx.Repository.GetSystemGuild(ctx.Guild.Id, target.Id);
 
@@ -361,10 +361,10 @@ public class SystemEdit
 
                 var msg = $"Your current system tag in '{ctx.Guild.Name}' is {settings.Tag.AsCode()}";
                 if (!settings.TagEnabled)
-                    msg += ", but it is currently **disabled**. To re-enable it, type `pk;s servertag -enable`.";
+                    msg += $", but it is currently **disabled**. To re-enable it, type `{ctx.DefaultPrefix}s servertag -enable`.";
                 else
                     msg +=
-                        ". To change it, type `pk;s servertag <tag>`. To clear it, type `pk;s servertag -clear`.";
+                        $". To change it, type `{ctx.DefaultPrefix}s servertag <tag>`. To clear it, type `{ctx.DefaultPrefix}s servertag -clear`.";
 
                 await ctx.Reply(msg);
                 return;
@@ -372,10 +372,10 @@ public class SystemEdit
 
             if (!settings.TagEnabled)
                 await ctx.Reply(
-                    $"Your global system tag is {target.Tag}, but it is **disabled** in this server. To re-enable it, type `pk;s servertag -enable`");
+                    $"Your global system tag is {target.Tag}, but it is **disabled** in this server. To re-enable it, type `{ctx.DefaultPrefix}s servertag -enable`");
             else
                 await ctx.Reply(
-                    $"You currently have no system tag specific to the server '{ctx.Guild.Name}'. To set one, type `pk;s servertag <tag>`. To disable the system tag in the current server, type `pk;s servertag -disable`.");
+                    $"You currently have no system tag specific to the server '{ctx.Guild.Name}'. To set one, type `{ctx.DefaultPrefix}s servertag <tag>`. To disable the system tag in the current server, type `{ctx.DefaultPrefix}s servertag -disable`.");
         }
 
         async Task Set()
@@ -469,7 +469,7 @@ public class SystemEdit
 
         var noPronounsSetMessage = "This system does not have pronouns set.";
         if (isOwnSystem)
-            noPronounsSetMessage += " To set some, type `pk;system pronouns <pronouns>`";
+            noPronounsSetMessage += $" To set some, type `{ctx.DefaultPrefix}system pronouns <pronouns>`";
 
         var format = ctx.MatchFormat();
 
@@ -496,8 +496,8 @@ public class SystemEdit
 
         if (!ctx.HasNext(false))
         {
-            await ctx.Reply($"{(isOwnSystem ? "Your" : "This system's")} current pronouns are **{target.Pronouns}**.\nTo print the pronouns with formatting, type `pk;system pronouns -raw`."
-            + (isOwnSystem ? " To clear them, type `pk;system pronouns -clear`."
+            await ctx.Reply($"{(isOwnSystem ? "Your" : "This system's")} current pronouns are **{target.Pronouns}**.\nTo print the pronouns with formatting, type `{ctx.DefaultPrefix}system pronouns -raw`."
+            + (isOwnSystem ? $" To clear them, type `{ctx.DefaultPrefix}system pronouns -clear`."
             : "")
             + $" Using {target.Pronouns.Length}/{Limits.MaxPronounsLength} characters.");
             return;
@@ -580,7 +580,7 @@ public class SystemEdit
                             .Title("System icon")
                             .Image(new Embed.EmbedImage(target.AvatarUrl.TryGetCleanCdnUrl()));
                         if (target.Id == ctx.System?.Id)
-                            ebS.Description("To clear, use `pk;system icon clear`.");
+                            ebS.Description($"To clear, use `{ctx.DefaultPrefix}system icon clear`.");
                         await ctx.Reply(embed: ebS.Build());
                         break;
                 }
@@ -663,7 +663,7 @@ public class SystemEdit
                             .Title("System server icon")
                             .Image(new Embed.EmbedImage(settings.AvatarUrl.TryGetCleanCdnUrl()));
                         if (target.Id == ctx.System?.Id)
-                            ebS.Description("To clear, use `pk;system servericon clear`.");
+                            ebS.Description($"To clear, use `{ctx.DefaultPrefix}system servericon clear`.");
                         await ctx.Reply(embed: ebS.Build());
                         break;
                 }
@@ -712,7 +712,7 @@ public class SystemEdit
                             .Title("System banner image")
                             .Image(new Embed.EmbedImage(target.BannerImage.TryGetCleanCdnUrl()));
                         if (target.Id == ctx.System?.Id)
-                            ebS.Description("To clear, use `pk;system banner clear`.");
+                            ebS.Description($"To clear, use `{ctx.DefaultPrefix}system banner clear`.");
                         await ctx.Reply(embed: ebS.Build());
                         break;
                 }
@@ -764,7 +764,7 @@ public class SystemEdit
         var warnMsg = $"{Emojis.Warn} Are you sure you want to delete your system? If so, reply to this message with your system's ID (`{target.DisplayHid(ctx.Config)}`).\n";
         if (!noExport)
             warnMsg += "**Note: this action is permanent,** but you will get a copy of your system's data that can be re-imported into PluralKit at a later date sent to you in DMs."
-                + " If you don't want this to happen, use `pk;s delete -no-export` instead.";
+                + $" If you don't want this to happen, use `{ctx.DefaultPrefix}s delete -no-export` instead.";
 
         await ctx.Reply(warnMsg);
         if (!await ctx.ConfirmWithReply(target.Hid, treatAsHid: true))
@@ -788,7 +788,7 @@ public class SystemEdit
             {
                 var dm = await _dmCache.GetOrCreateDmChannel(ctx.Author.Id);
                 var msg = await ctx.Rest.CreateMessage(dm,
-                    new MessageRequest { Content = $"{Emojis.Success} System deleted. If you want to set up your PluralKit system again, you can import the file below with `pk;import`." },
+                    new MessageRequest { Content = $"{Emojis.Success} System deleted. If you want to set up your PluralKit system again, you can import the file below with `{ctx.DefaultPrefix}import`." },
                     new[] { new MultipartFile("system.json", stream, null, null, null) });
                 await ctx.Rest.CreateMessage(dm, new MessageRequest { Content = $"<{msg.Attachments[0].Url}>" });
 
@@ -800,7 +800,7 @@ public class SystemEdit
             {
                 // If user has DMs closed, tell 'em to open them
                 throw new PKError(
-                    $"I couldn't send you a DM with your system's data before deleting your system. Either make sure your DMs are open, or use `pk;s delete -no-export` to delete your system without exporting first.");
+                    $"I couldn't send you a DM with your system's data before deleting your system. Either make sure your DMs are open, or use `{ctx.DefaultPrefix}s delete -no-export` to delete your system without exporting first.");
             }
         }
         else
@@ -832,10 +832,10 @@ public class SystemEdit
         {
             if (gs.ProxyEnabled)
                 await ctx.Reply(
-                    $"Proxying in {serverText} is currently **enabled** for your system. To disable it, type `pk;system proxy off`.");
+                    $"Proxying in {serverText} is currently **enabled** for your system. To disable it, type `{ctx.DefaultPrefix}system proxy off`.");
             else
                 await ctx.Reply(
-                    $"Proxying in {serverText} is currently **disabled** for your system. To enable it, type `pk;system proxy on`.");
+                    $"Proxying in {serverText} is currently **disabled** for your system. To enable it, type `{ctx.DefaultPrefix}system proxy on`.");
             return;
         }
 
@@ -867,7 +867,7 @@ public class SystemEdit
                 .Field(new Embed.Field("Current fronter(s)", target.FrontPrivacy.Explanation()))
                 .Field(new Embed.Field("Front/switch history", target.FrontHistoryPrivacy.Explanation()))
                 .Description(
-                    "To edit privacy settings, use the command:\n`pk;system privacy <subject> <level>`\n\n- `subject` is one of `name`, `avatar`, `description`, `banner`, `pronouns`, `list`, `front`, `fronthistory`, `groups`, or `all` \n- `level` is either `public` or `private`.");
+                    $"To edit privacy settings, use the command:\n`{ctx.DefaultPrefix}system privacy <subject> <level>`\n\n- `subject` is one of `name`, `avatar`, `description`, `banner`, `pronouns`, `list`, `front`, `fronthistory`, `groups`, or `all` \n- `level` is either `public` or `private`.");
             return ctx.Reply(embed: eb.Build());
         }
 

--- a/PluralKit.Bot/Commands/SystemFront.cs
+++ b/PluralKit.Bot/Commands/SystemFront.cs
@@ -17,7 +17,7 @@ public class SystemFront
 
     public async Task SystemFronter(Context ctx, PKSystem system)
     {
-        if (system == null) throw Errors.NoSystemError;
+        if (system == null) throw Errors.NoSystemError(ctx.DefaultPrefix);
         ctx.CheckSystemPrivacy(system.Id, system.FrontPrivacy);
 
         var sw = await ctx.Repository.GetLatestSwitch(system.Id);
@@ -34,7 +34,7 @@ public class SystemFront
             return;
         }
 
-        if (system == null) throw Errors.NoSystemError;
+        if (system == null) throw Errors.NoSystemError(ctx.DefaultPrefix);
         ctx.CheckSystemPrivacy(system.Id, system.FrontHistoryPrivacy);
 
         var totalSwitches = await ctx.Repository.GetSwitchCount(system.Id);
@@ -108,7 +108,7 @@ public class SystemFront
 
     public async Task FrontPercent(Context ctx, PKSystem? system = null, PKGroup? group = null)
     {
-        if (system == null && group == null) throw Errors.NoSystemError;
+        if (system == null && group == null) throw Errors.NoSystemError(ctx.DefaultPrefix);
         if (system == null) system = await GetGroupSystem(ctx, group);
 
         ctx.CheckSystemPrivacy(system.Id, system.FrontHistoryPrivacy);

--- a/PluralKit.Bot/Commands/SystemLink.cs
+++ b/PluralKit.Bot/Commands/SystemLink.cs
@@ -18,7 +18,7 @@ public class SystemLink
 
         var existingAccount = await ctx.Repository.GetSystemByAccount(account.Id);
         if (existingAccount != null)
-            throw Errors.AccountInOtherSystem(existingAccount, ctx.Config);
+            throw Errors.AccountInOtherSystem(existingAccount, ctx.Config, ctx.DefaultPrefix);
 
         var msg = $"{account.Mention()}, please confirm the link.";
         if (!await ctx.PromptYesNo(msg, "Confirm", account, false)) throw Errors.MemberLinkCancelled;
@@ -36,7 +36,7 @@ public class SystemLink
 
         var accountIds = (await ctx.Repository.GetSystemAccounts(ctx.System.Id)).ToList();
         if (!accountIds.Contains(id)) throw Errors.AccountNotLinked;
-        if (accountIds.Count == 1) throw Errors.UnlinkingLastAccount;
+        if (accountIds.Count == 1) throw Errors.UnlinkingLastAccount(ctx.DefaultPrefix);
 
         var msg = $"Are you sure you want to unlink <@{id}> from your system?";
         if (!await ctx.PromptYesNo(msg, "Unlink")) throw Errors.MemberUnlinkCancelled;

--- a/PluralKit.Bot/Commands/SystemList.cs
+++ b/PluralKit.Bot/Commands/SystemList.cs
@@ -10,7 +10,7 @@ public class SystemList
 {
     public async Task MemberList(Context ctx, PKSystem target)
     {
-        if (target == null) throw Errors.NoSystemError;
+        if (target == null) throw Errors.NoSystemError(ctx.DefaultPrefix);
         ctx.CheckSystemPrivacy(target.Id, target.MemberListPrivacy);
 
         // explanation of privacy lookup here:

--- a/PluralKit.Bot/Errors.cs
+++ b/PluralKit.Bot/Errors.cs
@@ -36,11 +36,11 @@ public static class Errors
 
     public static PKError NotOwnInfo => new("You cannot look up private information of another system.");
 
-    public static PKError NoSystemError =>
-        new("You do not have a system registered with PluralKit. To create one, type `pk;system new`.");
+    public static PKError NoSystemError(string prefix) =>
+        new($"You do not have a system registered with PluralKit. To create one, type `{prefix}system new`.");
 
-    public static PKError ExistingSystemError => new(
-        "You already have a system registered with PluralKit. To view it, type `pk;system`. If you'd like to delete your system and start anew, type `pk;system delete`, or if you'd like to unlink this account from it, type `pk;unlink`.");
+    public static PKError ExistingSystemError(string prefix) => new(
+        $"You already have a system registered with PluralKit. To view it, type `{prefix}system`. If you'd like to delete your system and start anew, type `{prefix}system delete`, or if you'd like to unlink this account from it, type `{prefix}unlink`.");
 
     public static PKError MissingMemberError =>
         new PKSyntaxError("You need to specify a member to run this command on.");
@@ -61,8 +61,8 @@ public static class Errors
     public static PKError AccountAlreadyLinked => new("That account is already linked to your system.");
     public static PKError AccountNotLinked => new("That account isn't linked to your system.");
 
-    public static PKError UnlinkingLastAccount => new(
-        "Since this is the only account linked to this system, you cannot unlink it (as that would leave your system account-less). If you would like to delete your system, use `pk;system delete`.");
+    public static PKError UnlinkingLastAccount(string prefix) => new(
+        $"Since this is the only account linked to this system, you cannot unlink it (as that would leave your system account-less). If you would like to delete your system, use `{prefix}system delete`.");
 
     public static PKError MemberLinkCancelled => new("Member link cancelled.");
     public static PKError MemberUnlinkCancelled => new("Member unlink cancelled.");
@@ -120,8 +120,8 @@ public static class Errors
     public static PKError UrlTooLong(string url) =>
         new($"The given URL is too long ({url.Length}/{Limits.MaxUriLength} characters).");
 
-    public static PKError AccountInOtherSystem(PKSystem system, SystemConfig config) =>
-        new($"The mentioned account is already linked to another system (see `pk;system {system.DisplayHid(config)}`).");
+    public static PKError AccountInOtherSystem(PKSystem system, SystemConfig config, string prefix) =>
+        new($"The mentioned account is already linked to another system (see `{prefix}system {system.DisplayHid(config)}`).");
 
     public static PKError SameSwitch(ICollection<PKMember> members, LookupContext ctx)
     {
@@ -171,10 +171,10 @@ public static class Errors
         $"That member does not have the proxy tag {tagToRemove.ProxyString.AsCode()}. The member currently has these tags: {member.ProxyTagsString()}");
 
     public static PKError LegacyAlreadyHasProxyTag(ProxyTag requested, PKMember member, Context ctx) => new(
-        $"This member already has more than one proxy tag set: {member.ProxyTagsString()}\nConsider using the {$"pk;member {member.Reference(ctx)} proxy add {requested.ProxyString}".AsCode()} command instead.");
+        $"This member already has more than one proxy tag set: {member.ProxyTagsString()}\nConsider using the {$"{ctx.DefaultPrefix}member {member.Reference(ctx)} proxy add {requested.ProxyString}".AsCode()} command instead.");
 
     public static PKError EmptyProxyTags(PKMember member, Context ctx) => new(
-        $"The example proxy `text` is equivalent to having no proxy tags at all, since there are no symbols or brackets on either end. If you'd like to clear your proxy tags, use `pk;member {member.Reference(ctx)} proxy clear`.");
+        $"The example proxy `text` is equivalent to having no proxy tags at all, since there are no symbols or brackets on either end. If you'd like to clear your proxy tags, use `{ctx.DefaultPrefix}member {member.Reference(ctx)} proxy clear`.");
 
     public static PKError GenericCancelled() => new("Operation cancelled.");
 

--- a/PluralKit.Bot/Handlers/InteractionCreated.cs
+++ b/PluralKit.Bot/Handlers/InteractionCreated.cs
@@ -17,15 +17,17 @@ public class InteractionCreated: IEventHandler<InteractionCreateEvent>
     private readonly ILifetimeScope _services;
     private readonly ILogger _logger;
     private readonly ModelRepository _repo;
+    private readonly BotConfig _config;
 
     public InteractionCreated(InteractionDispatchService interactionDispatch, ApplicationCommandTree commandTree,
-                              ILifetimeScope services, ILogger logger, ModelRepository repo)
+                              ILifetimeScope services, ILogger logger, ModelRepository repo, BotConfig config)
     {
         _interactionDispatch = interactionDispatch;
         _commandTree = commandTree;
         _services = services;
         _logger = logger;
         _repo = repo;
+        _config = config;
     }
 
     public async Task Handle(int shardId, InteractionCreateEvent evt)
@@ -42,7 +44,7 @@ public class InteractionCreated: IEventHandler<InteractionCreateEvent>
                 if (customId == null) return;
 
                 if (customId.Contains("help-menu"))
-                    await Help.ButtonClick(ctx);
+                    await Help.ButtonClick(ctx, (_config.Prefixes[0] ?? BotConfig.DefaultPrefixes[0]));
                 else
                     await _interactionDispatch.Dispatch(customId, ctx);
 

--- a/PluralKit.Bot/Handlers/MessageCreated.cs
+++ b/PluralKit.Bot/Handlers/MessageCreated.cs
@@ -131,7 +131,7 @@ public class MessageCreated: IEventHandler<MessageCreateEvent>
             var config = system != null ? await _repo.GetSystemConfig(system.Id) : null;
             var guildConfig = guild != null ? await _repo.GetGuild(guild.Id) : null;
 
-            await _tree.ExecuteCommand(new Context(_services, shardId, guild, channel, evt, cmdStart, system, config, guildConfig));
+            await _tree.ExecuteCommand(new Context(_services, shardId, guild, channel, evt, cmdStart, system, config, guildConfig, _config.Prefixes ?? BotConfig.DefaultPrefixes));
         }
         catch (PKError)
         {
@@ -174,7 +174,7 @@ public class MessageCreated: IEventHandler<MessageCreateEvent>
 
         try
         {
-            return await _proxy.HandleIncomingMessage(evt, ctx, guild, channel, true, botPermissions);
+            return await _proxy.HandleIncomingMessage(evt, ctx, guild, channel, true, botPermissions, (_config.Prefixes[0] ?? BotConfig.DefaultPrefixes[0]));
         }
 
         // Catch any failed proxy checks so they get ignored in the global error handler

--- a/PluralKit.Bot/Handlers/MessageEdited.cs
+++ b/PluralKit.Bot/Handlers/MessageEdited.cs
@@ -84,7 +84,7 @@ public class MessageEdited: IEventHandler<MessageUpdateEvent>
         try
         {
             await _proxy.HandleIncomingMessage(equivalentEvt, ctx, allowAutoproxy: false, guild: guild,
-                channel: channel, botPermissions: botPermissions);
+                channel: channel, botPermissions: botPermissions, prefix: (_config.Prefixes[0] ?? BotConfig.DefaultPrefixes[0]));
         }
         // Catch any failed proxy checks so they get ignored in the global error handler
         catch (ProxyService.ProxyChecksFailedException) { }

--- a/PluralKit.Bot/Services/EmbedService.cs
+++ b/PluralKit.Bot/Services/EmbedService.cs
@@ -79,7 +79,7 @@ public class EmbedService
             {
                 var memberStr = string.Join(", ", switchMembers.Select(m => m.NameFor(ctx)));
                 if (memberStr.Length > 200)
-                    memberStr = $"[too many to show, see `pk;system {system.DisplayHid(cctx.Config)} fronters`]";
+                    memberStr = $"[too many to show, see `{cctx.DefaultPrefix}system {system.DisplayHid(cctx.Config)} fronters`]";
                 eb.Field(new Embed.Field("Fronter".ToQuantity(switchMembers.Count, ShowQuantityAs.None), memberStr));
             }
         }
@@ -126,9 +126,9 @@ public class EmbedService
         {
             if (memberCount > 0)
                 eb.Field(new Embed.Field($"Members ({memberCount})",
-                    $"(see `pk;system {system.DisplayHid(cctx.Config)} list` or `pk;system {system.DisplayHid(cctx.Config)} list full`)", true));
+                    $"(see `{cctx.DefaultPrefix}system {system.DisplayHid(cctx.Config)} list` or `{cctx.DefaultPrefix}system {system.DisplayHid(cctx.Config)} list full`)", true));
             else
-                eb.Field(new Embed.Field($"Members ({memberCount})", "Add one with `pk;member new`!", true));
+                eb.Field(new Embed.Field($"Members ({memberCount})", $"Add one with `{cctx.DefaultPrefix}member new`!", true));
         }
 
         if (system.DescriptionFor(ctx) is { } desc)
@@ -284,13 +284,13 @@ public class EmbedService
             if (memberCount == 0 && pctx == LookupContext.ByOwner)
                 // Only suggest the add command if this is actually the owner lol
                 eb.Field(new Embed.Field("Members (0)",
-                    $"Add one with `pk;group {target.Reference(ctx)} add <member>`!"));
+                    $"Add one with `{ctx.DefaultPrefix}group {target.Reference(ctx)} add <member>`!"));
             else
             {
                 var name = pctx == LookupContext.ByOwner
                     ? target.Reference(ctx)
                     : target.DisplayHid(ctx.Config);
-                eb.Field(new Embed.Field($"Members ({memberCount})", $"(see `pk;group {name} list`)"));
+                eb.Field(new Embed.Field($"Members ({memberCount})", $"(see `{ctx.DefaultPrefix}group {name} list`)"));
             }
         }
 


### PR DESCRIPTION
This commit changes all\* instances of `pk;` in commands to whatever the bot's current primary prefix is. This doesn't visibly affect the main bot but it's beneficial for forks and self-hosts.