### PR TITLE
feat: cfg option to log a switch when proxying

### DIFF
--- a/PluralKit.Bot/CommandMeta/CommandTree.cs
+++ b/PluralKit.Bot/CommandMeta/CommandTree.cs
@@ -596,6 +596,8 @@ public partial class CommandTree
             return ctx.Execute<Config>(null, m => m.HidListPadding(ctx));
         if (ctx.MatchMultiple(new[] { "member", "group" }, new[] { "limit" }) || ctx.Match("limit"))
             return ctx.Execute<Config>(null, m => m.LimitUpdate(ctx));
+        if (ctx.MatchMultiple(new[] { "proxy" }, new[] { "switch" }) || ctx.Match("proxyswitch", "ps"))
+            return ctx.Execute<Config>(null, m => m.ProxySwitch(ctx));
 
         // todo: maybe add the list of configuration keys here?
         return ctx.Reply($"{Emojis.Error} Could not find a setting with that name. Please see `pk;commands config` for the list of possible config settings.");

--- a/PluralKit.Bot/Commands/Config.cs
+++ b/PluralKit.Bot/Commands/Config.cs
@@ -123,6 +123,13 @@ public class Config
             "off"
         ));
 
+        items.Add(new(
+            "Proxy Switch",
+            "Whether using a proxy tag logs a switch",
+            EnabledDisabled(ctx.Config.ProxySwitch),
+            "disabled"
+        ));
+
         await ctx.Paginate<PaginatedConfigItem>(
             items.ToAsyncEnumerable(),
             items.Count,
@@ -535,6 +542,20 @@ public class Config
             await ctx.Reply("5-character IDs displayed in lists will now have a padding space added to the end.");
         }
         else throw new PKError(badInputError);
+    }
+
+    public async Task ProxySwitch(Context ctx)
+    {
+        if (!ctx.HasNext())
+        {
+            var msg = $"Logging a switch every time a proxy tag is used is currently **{EnabledDisabled(ctx.Config.ProxySwitch)}**.";
+            await ctx.Reply(msg);
+            return;
+        }
+
+        var newVal = ctx.MatchToggle(false);
+        await ctx.Repository.UpdateSystemConfig(ctx.System.Id, new() { ProxySwitch = newVal });
+        await ctx.Reply($"Logging a switch every time a proxy tag is used is now {EnabledDisabled(newVal)}.");
     }
 
     public Task LimitUpdate(Context ctx)

--- a/PluralKit.Bot/Proxy/ProxyService.cs
+++ b/PluralKit.Bot/Proxy/ProxyService.cs
@@ -506,6 +506,10 @@ public class ProxyService
 
         Task DispatchWebhook() => _dispatch.Dispatch(ctx.SystemId.Value, sentMessage);
 
+        Task MaybeLogSwitch() => (ctx.ProxySwitch && !Array.Exists(ctx.LastSwitchMembers, element => element == match.Member.Id))
+            ? _db.Execute(conn => _repo.AddSwitch(conn, (SystemId)ctx.SystemId, new[] { match.Member.Id }))
+            : Task.CompletedTask;
+
         async Task DeleteProxyTriggerMessage()
         {
             if (!deletePrevious)
@@ -539,7 +543,8 @@ public class ProxyService
             UpdateMemberForSentMessage(),
             LogMessageToChannel(),
             SaveLatchAutoproxy(),
-            DispatchWebhook()
+            DispatchWebhook(),
+            MaybeLogSwitch()
         );
     }
 

--- a/PluralKit.Core/Database/Functions/MessageContext.cs
+++ b/PluralKit.Core/Database/Functions/MessageContext.cs
@@ -31,5 +31,6 @@ public class MessageContext
     public int? LatchTimeout { get; }
     public bool CaseSensitiveProxyTags { get; }
     public bool ProxyErrorMessageEnabled { get; }
+    public bool ProxySwitch { get; }
     public bool DenyBotUsage { get; }
 }

--- a/PluralKit.Core/Database/Functions/functions.sql
+++ b/PluralKit.Core/Database/Functions/functions.sql
@@ -9,6 +9,7 @@
         latch_timeout integer,
         case_sensitive_proxy_tags bool,
         proxy_error_message_enabled bool,
+        proxy_switch bool,
 
         tag_enabled bool,
         proxy_enabled bool,
@@ -40,6 +41,7 @@ as $$
         system_config.latch_timeout                    as latch_timeout,
         system_config.case_sensitive_proxy_tags        as case_sensitive_proxy_tags,
         system_config.proxy_error_message_enabled      as proxy_error_message_enabled,
+        system_config.proxy_switch                     as proxy_switch,
 
         -- system_guild table
         coalesce(system_guild.tag_enabled, true)       as tag_enabled,

--- a/PluralKit.Core/Database/Migrations/45.sql
+++ b/PluralKit.Core/Database/Migrations/45.sql
@@ -1,0 +1,6 @@
+-- database version 45
+-- add new config setting "proxy_switch"
+
+alter table system_config add column proxy_switch bool default false;
+
+update info set schema_version = 45;

--- a/PluralKit.Core/Database/Utils/DatabaseMigrator.cs
+++ b/PluralKit.Core/Database/Utils/DatabaseMigrator.cs
@@ -9,7 +9,7 @@ namespace PluralKit.Core;
 internal class DatabaseMigrator
 {
     private const string RootPath = "PluralKit.Core.Database"; // "resource path" root for SQL files
-    private const int TargetSchemaVersion = 44;
+    private const int TargetSchemaVersion = 45;
     private readonly ILogger _logger;
 
     public DatabaseMigrator(ILogger logger)

--- a/PluralKit.Core/Models/Patch/SystemConfigPatch.cs
+++ b/PluralKit.Core/Models/Patch/SystemConfigPatch.cs
@@ -22,7 +22,7 @@ public class SystemConfigPatch: PatchObject
     public Partial<bool> HidDisplaySplit { get; set; }
     public Partial<bool> HidDisplayCaps { get; set; }
     public Partial<SystemConfig.HidPadFormat> HidListPadding { get; set; }
-
+    public Partial<bool> ProxySwitch { get; set; }
 
     public override Query Apply(Query q) => q.ApplyPatch(wrapper => wrapper
         .With("ui_tz", UiTz)
@@ -39,6 +39,7 @@ public class SystemConfigPatch: PatchObject
         .With("hid_display_split", HidDisplaySplit)
         .With("hid_display_caps", HidDisplayCaps)
         .With("hid_list_padding", HidListPadding)
+        .With("proxy_switch", ProxySwitch)
     );
 
     public new void AssertIsValid()
@@ -103,6 +104,9 @@ public class SystemConfigPatch: PatchObject
         if (HidListPadding.IsPresent)
             o.Add("hid_list_padding", HidListPadding.Value.ToUserString());
 
+        if (ProxySwitch.IsPresent)
+            o.Add("proxy_switch", ProxySwitch.Value);
+
         return o;
     }
 
@@ -139,6 +143,9 @@ public class SystemConfigPatch: PatchObject
 
         if (o.ContainsKey("hid_display_caps"))
             patch.HidDisplayCaps = o.Value<bool>("hid_display_caps");
+
+        if (o.ContainsKey("proxy_switch"))
+            patch.ProxySwitch = o.Value<bool>("proxy_switch");
 
         return patch;
     }

--- a/PluralKit.Core/Models/SystemConfig.cs
+++ b/PluralKit.Core/Models/SystemConfig.cs
@@ -24,6 +24,7 @@ public class SystemConfig
     public bool HidDisplaySplit { get; }
     public bool HidDisplayCaps { get; }
     public HidPadFormat HidListPadding { get; }
+    public bool ProxySwitch { get; }
 
     public enum HidPadFormat
     {
@@ -52,6 +53,7 @@ public static class SystemConfigExt
         o.Add("hid_display_split", cfg.HidDisplaySplit);
         o.Add("hid_display_caps", cfg.HidDisplayCaps);
         o.Add("hid_list_padding", cfg.HidListPadding.ToUserString());
+        o.Add("proxy_switch", cfg.ProxySwitch);
 
         o.Add("description_templates", JArray.FromObject(cfg.DescriptionTemplates));
 


### PR DESCRIPTION
Note: This ignores message deletions (including by reproxy). Adding in reproxy support may be possible but seems like way more trouble than it's worth (you have to figure out if the switch was triggered by the message being reproxied or by something else), but I don't think deleted message support is feasible at all. 