### PR TITLE
Update documentation according to Eth's list

### DIFF
--- a/docs/content/command-list.md
+++ b/docs/content/command-list.md
@@ -124,7 +124,7 @@ You can have a space after `pk;`, e.g. `pk;system` and `pk; system` will do the 
 - `pk;switch [member...]` - Registers a switch with the given members.
 - `pk;switch out` - Registers a 'switch-out' - a switch with no associated members.
 - `pk;switch edit <member...|out>` - Edits the members in the latest switch.
-- `pk;switch add <member...>` - Makes a new switch based off the current switch with the listed members added or removed.
+- `pk;switch add <member...>` - Makes a new switch based off the current switch with the listed members added or removed. Has an alias as `pk;switch copy <member...>`.
 - `pk;switch move <time>` - Moves the latest switch backwards in time.
 - `pk;switch delete` - Deletes the latest switch.
 - `pk;switch delete all` - Deletes all logged switches.

--- a/docs/content/command-list.md
+++ b/docs/content/command-list.md
@@ -124,7 +124,7 @@ You can have a space after `pk;`, e.g. `pk;system` and `pk; system` will do the 
 - `pk;switch [member...]` - Registers a switch with the given members.
 - `pk;switch out` - Registers a 'switch-out' - a switch with no associated members.
 - `pk;switch edit <member...|out>` - Edits the members in the latest switch.
-- `pk;switch add <member...>` - Makes a new switch based off the current switch with the listed members added or removed. Has an alias as `pk;switch copy <member...>`.
+- `pk;switch copy <member...>` - Makes a new switch based off the current switch with the listed members added or removed.
 - `pk;switch move <time>` - Moves the latest switch backwards in time.
 - `pk;switch delete` - Deletes the latest switch.
 - `pk;switch delete all` - Deletes all logged switches.

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -140,7 +140,7 @@ specifying an exact time zone code is the best way. To get your local time zone 
 You can see the full list [here, on Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) (see the column *TZ database name*).
 You can also search by country code, either by giving the two-character [*ISO-3166-1 alpha-2* country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements) (e.g. `GB` or `DE`), or just by a country flag emoji (e.g. `:flag_gb:` 🇬🇧 or `:flag_de:` 🇩🇪).
 
-To clear a time zone, type `pk;config timezone` without any parameters.
+To clear a time zone, type `pk;config timezone clear`. Note that this does not ask for confirmation!
 
 ### Deleting a system
 If you want to delete your own system, simply use the command:

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -772,13 +772,14 @@ For example:
 ### Group privacy
 
 Additionally, groups also have privacy settings.
-- Visibility *( whether the group shows up on member cards )*
-- Member list
+
 - Name
 - Description
-- Icon
 - Banner
+- Icon
+- Member list
 - Metadata *( group creation date )*
+- Visibility *( whether the group shows up on member cards )*
 
 As with system and member privacy, each can be set to **public** or **private**. The same rules apply for how they are shown, too. When set to **public**, anyone who queries your system (by account or system ID, or through the API), will see this information. When set to **private**, the information will only be shown when *you yourself* query the information. The cards will still be displayed in the channel the commands are run in, so it's still your responsibility not to pull up information in servers where you don't want it displayed.
 
@@ -795,7 +796,7 @@ To update a group's privacy, you can use the command:
   * `description`
   * `banner`
   * `avatar`
-  * `pronouns`
+  * `members`
   * `metadata`
   * `visiblity`
   * `all` (to change all subjects at once)

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -769,6 +769,46 @@ For example:
     pk;member Robert privacy birthday public
     pk;member Skyler privacy all private
 
+### Group privacy
+
+Additionally, groups also have privacy settings.
+- Visibility *( whether the group shows up on member cards )*
+- Member list
+- Name
+- Description
+- Icon
+- Banner
+- Metadata *( group creation date )*
+
+As with system and member privacy, each can be set to **public** or **private**. The same rules apply for how they are shown, too. When set to **public**, anyone who queries your system (by account or system ID, or through the API), will see this information. When set to **private**, the information will only be shown when *you yourself* query the information. The cards will still be displayed in the channel the commands are run in, so it's still your responsibility not to pull up information in servers where you don't want it displayed.
+
+As with member privacy, there are two catches:
+- When the **name** is set to private, it will be replaced by the group's **display name**, but only if they have one! If the group has no display name, **name privacy will not do anything**. PluralKit still needs some way to refer to a group by name :) 
+- When **visibility** is set to private, the group will not show up in group lists unless `-all` is used in the command (and you are part of the system).
+
+To update a group's privacy, you can use the command:
+
+    pk;group <group> privacy <subject> <level>
+
+* `subject` is one of:
+  * `name`
+  * `description`
+  * `banner`
+  * `avatar`
+  * `pronouns`
+  * `metadata`
+  * `visiblity`
+  * `all` (to change all subjects at once)
+
+* `level` is either `public` or `private`
+
+For example:
+
+    pk;group MyGroup privacy visibility private
+    pk;group "My Group" privacy description public
+    pk;group SuperCoolGroup privacy banner public
+    pk;group AwesomePeople privacy all private
+
 ## Importing and exporting data
 If you're a user of another proxy bot (e.g. Tupperbox), or you want to import a saved system backup, you can use the importing and exporting commands. Note, if you are on a mobile device, using the links is recommended - using the .json file from either bot may not work as Discord tends to break the file on download/upload.
 

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -453,7 +453,7 @@ You can
 
 #### Pinging the user who sent it
 If you'd like to "ping" the account behind a proxied message without having to query the message and ping them yourself,
-you can react to the message with the `:bell:` :bell: emoji (or `:exclamation:` :exclamation:, or even `:ping_pong:` :ping_pong:), and PluralKit will ping the relevant member and account in the same channel on your behalf with a link to the message you reacted to.
+you can react to the message with the `:bell:` :bell: emoji (or `:bellhop:` :bellhop:, `:exclamation:` :exclamation:, or even `:ping_pong:` :ping_pong:), and PluralKit will ping the relevant member and account in the same channel on your behalf with a link to the message you reacted to.
 
 ## Autoproxy
 The bot's *autoproxy* feature allows you to have messages be proxied without directly including the proxy tags. Autoproxy can be set up in various ways. There are three autoproxy modes currently implemented:

--- a/docs/content/user-guide.md
+++ b/docs/content/user-guide.md
@@ -778,8 +778,8 @@ Additionally, groups also have privacy settings.
 - Banner
 - Icon
 - Member list
-- Metadata *( group creation date )*
-- Visibility *( whether the group shows up on member cards )*
+- Metadata *(group creation date)*
+- Visibility *(whether the group shows up on member cards)*
 
 As with system and member privacy, each can be set to **public** or **private**. The same rules apply for how they are shown, too. When set to **public**, anyone who queries your system (by account or system ID, or through the API), will see this information. When set to **private**, the information will only be shown when *you yourself* query the information. The cards will still be displayed in the channel the commands are run in, so it's still your responsibility not to pull up information in servers where you don't want it displayed.
 


### PR DESCRIPTION
I did not touch `pk;scfg logclean` and related items, as I'm not knowledgeable enough on that topic.

Resolves:
> Docs > user guide > interacting with proxied msgs > pinging the user who sent it:
> Does not list 🛎️ emoji

> Docs > command list > group commands
> pk;group <group> privacy - checks the groups privacy settings
> this command is missing(?), member and system command have this command + the command to change a privacy setting under
> 2nd inconsistency is that the group privacy command in docs is written differently than the commands listed in members & system

> command inconsistency bot vs docs
> Docs > user guide > system management > setting a system timezone
> 
> Tells you the command "pk;config timezone, without any parameters" will clear a timezone
> - the command should be pk;config timezone -clear/clear afaik
> - - clearing a timezone does not ask if you're sure on the change (setting a timezone asks if you're sure)

> Missing from docs > command list
> pk;sw copy <member 1> [member 2] [...] - Make a duplicate of a switch with members appended with this command
    