### PR TITLE
Add "as text" to the redirect to the error support channel

### DIFF
--- a/PluralKit.Bot/Services/ErrorMessageService.cs
+++ b/PluralKit.Bot/Services/ErrorMessageService.cs
@@ -116,7 +116,7 @@ public class ErrorMessageService
         return new EmbedBuilder()
             .Color(0xE74C3C)
             .Title("Internal error occurred")
-            .Description($"For support, please send the error code above in {channelInfo} with a description of what you were doing at the time.")
+            .Description($"For support, please send the error code above as text in {channelInfo} with a description of what you were doing at the time.")
             .Footer(new Embed.EmbedFooter(errorId))
             .Timestamp(now.ToDateTimeOffset().ToString("O"))
             .Build();


### PR DESCRIPTION
Many users send a screenshot of the error embed rather than sending the error code as text. Perhaps this would help?