### PR TITLE
fix(scheduled_tasks): update for k8s

### DIFF
--- a/crates/libpk/src/_config.rs
+++ b/crates/libpk/src/_config.rs
@@ -88,6 +88,7 @@ pub struct ScheduledTasksConfig {
     pub set_guild_count: bool,
     pub expected_gateway_count: usize,
     pub gateway_url: String,
+    pub vm_url: String,
 }
 
 fn _metrics_default() -> bool {


### PR DESCRIPTION
- adds 'vm_url' env ('pluralkit__scheduled_tasks__vm_url') for VictoriaMetrics and updates url to be compatible
- updates format of gateway url for k8s