### PR TITLE
fix(bot): don't unnecessarily require permission to create forum threads

### DIFF
--- a/Myriad/Extensions/PermissionExtensions.cs
+++ b/Myriad/Extensions/PermissionExtensions.cs
@@ -94,8 +94,11 @@ public static class PermissionExtensions
         if ((perms & PermissionSet.ViewChannel) == 0)
             perms &= ~NeedsViewChannel;
 
-        if ((perms & PermissionSet.SendMessages) == 0 && (!isThread || (perms & PermissionSet.SendMessagesInThreads) == 0))
-            perms &= ~NeedsSendMessages;
+        if ((perms & PermissionSet.SendMessages) == 0)
+            if (channel.Type == Channel.ChannelType.GuildForum && (perms & PermissionSet.SendMessagesInThreads) != 0)
+                perms |= PermissionSet.SendMessages;
+            else if (!isThread || (perms & PermissionSet.SendMessagesInThreads) == 0)
+                perms &= ~NeedsSendMessages;
 
         return perms;
     }


### PR DESCRIPTION
This logic is a bit thorny and probably deserves closer inspection, but experimentally this seems to work as expected.