### PR TITLE
fix: use Serilog submodule in Myriad

### DIFF
--- a/Myriad/Myriad.csproj
+++ b/Myriad/Myriad.csproj
@@ -21,11 +21,14 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\Serilog\src\Serilog\Serilog.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="NodaTime" Version="3.2.0" />
         <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.1.0" />
         <PackageReference Include="Polly" Version="8.5.0" />
         <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
-        <PackageReference Include="Serilog" Version="4.2.0" />
         <PackageReference Include="StackExchange.Redis" Version="2.8.22" />
         <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     </ItemGroup>

--- a/Myriad/packages.lock.json
+++ b/Myriad/packages.lock.json
@@ -33,12 +33,6 @@
         "resolved": "1.1.1",
         "contentHash": "1MUQLiSo4KDkQe6nzQRhIU05lm9jlexX5BVsbuw0SL82ynZ+GzAHQxJVDPVBboxV37Po3SG077aX8DuSy8TkaA=="
       },
-      "Serilog": {
-        "type": "Direct",
-        "requested": "[4.2.0, )",
-        "resolved": "4.2.0",
-        "contentHash": "gmoWVOvKgbME8TYR+gwMf7osROiWAURterc6Rt2dQyX7wtjZYpqFiA/pY6ztjGQKKV62GGCyOcmtP1UKMHgSmA=="
-      },
       "StackExchange.Redis": {
         "type": "Direct",
         "requested": "[2.8.22, )",
@@ -90,6 +84,9 @@
         "type": "Transitive",
         "resolved": "5.0.1",
         "contentHash": "qEePWsaq9LoEEIqhbGe6D5J8c9IqQOUuTzzV6wn1POlfdLkJliZY3OlB0j0f17uMWlqZYjH7txj+2YbyrIA8Yg=="
+      },
+      "serilog": {
+        "type": "Project"
       }
     }
   }

--- a/PluralKit.Bot/packages.lock.json
+++ b/PluralKit.Bot/packages.lock.json
@@ -416,11 +416,6 @@
         "resolved": "1.0.9",
         "contentHash": "RkQGXIrqHjD5h1mqefhgCbkaSdRYNRG5rrbzyw5zeLWiS0K1wq9xR3cNhQdzYR2MsKZ3GN523yRUsEQIMPxh3Q=="
       },
-      "Serilog": {
-        "type": "Transitive",
-        "resolved": "4.2.0",
-        "contentHash": "gmoWVOvKgbME8TYR+gwMf7osROiWAURterc6Rt2dQyX7wtjZYpqFiA/pY6ztjGQKKV62GGCyOcmtP1UKMHgSmA=="
-      },
       "Serilog.Extensions.Logging": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -768,7 +763,7 @@
           "NodaTime.Serialization.JsonNet": "[3.1.0, )",
           "Polly": "[8.5.0, )",
           "Polly.Contrib.WaitAndRetry": "[1.1.1, )",
-          "Serilog": "[4.2.0, )",
+          "Serilog": "[4.1.0, )",
           "StackExchange.Redis": "[2.8.22, )",
           "System.Linq.Async": "[6.0.1, )"
         }
@@ -811,6 +806,9 @@
           "System.Interactive.Async": "[6.0.1, )",
           "ipnetwork2": "[3.0.667, )"
         }
+      },
+      "serilog": {
+        "type": "Project"
       }
     }
   }

--- a/PluralKit.Tests/packages.lock.json
+++ b/PluralKit.Tests/packages.lock.json
@@ -530,11 +530,6 @@
         "resolved": "4.13.0",
         "contentHash": "Wfw3M1WpFcrYaGzPm7QyUTfIOYkVXQ1ry6p4WYjhbLz9fPwV23SGQZTFDpdox67NHM0V0g1aoQ4YKLm4ANtEEg=="
       },
-      "Serilog": {
-        "type": "Transitive",
-        "resolved": "4.2.0",
-        "contentHash": "gmoWVOvKgbME8TYR+gwMf7osROiWAURterc6Rt2dQyX7wtjZYpqFiA/pY6ztjGQKKV62GGCyOcmtP1UKMHgSmA=="
-      },
       "Serilog.AspNetCore": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -983,7 +978,7 @@
           "NodaTime.Serialization.JsonNet": "[3.1.0, )",
           "Polly": "[8.5.0, )",
           "Polly.Contrib.WaitAndRetry": "[1.1.1, )",
-          "Serilog": "[4.2.0, )",
+          "Serilog": "[4.1.0, )",
           "StackExchange.Redis": "[2.8.22, )",
           "System.Linq.Async": "[6.0.1, )"
         }
@@ -1047,6 +1042,9 @@
           "System.Interactive.Async": "[6.0.1, )",
           "ipnetwork2": "[3.0.667, )"
         }
+      },
+      "serilog": {
+        "type": "Project"
       }
     }
   }


### PR DESCRIPTION
This prevents both Nuget and local Serilog from appearing in builds, which can cause confusing build and runtime failures.