### PR TITLE
Mark member guild settings model's `guild_id` as optional

### DIFF
--- a/docs/content/api/models.md
+++ b/docs/content/api/models.md
@@ -196,7 +196,7 @@ This model is used when querying system settings without authenticating, or for 
 
 |key|type|notes|
 |---|---|---|
-|guild_id|snowflake|only sent if the guild ID isn't already known (in dispatch payloads)|
+|?guild_id|snowflake|only sent if the guild ID isn't already known (in dispatch payloads)|
 |display_name|?string|100-character limit|
 |avatar_url|?string|256-character limit, must be a publicly-accessible URL|
 |keep_proxy|?boolean||


### PR DESCRIPTION
I'm not certain if this is correct (please close this PR if it isn't), but every other instance where `guild_id`'s notes contains “only sent if the guild ID isn't already known” is optional.  (Plus, “only sent” sort of implies that it's optional.)