### PR TITLE
fix(docs): add missing api error code 50001

### DIFF
--- a/docs/content/api/errors.md
+++ b/docs/content/api/errors.md
@@ -59,3 +59,4 @@ When something goes wrong, the API will send back a 4xx HTTP status code, along 
 |40004|400|Member list identical to current fronter list.|
 |40005|400|Switch with provided timestamp already exists.|
 |40006|400|Invalid switch ID.|
+|50001|501|Unimplemented.|


### PR DESCRIPTION
This is thrown by at least `https://api.pluralkit.me/v2/systems/@me/autoproxy` when not specifying a `guild_id`