### PR TITLE
Add support for a time placeholder in URLs (prototype)

### DIFF
--- a/PluralKit.Bot/Utils/AvatarUtils.cs
+++ b/PluralKit.Bot/Utils/AvatarUtils.cs
@@ -14,6 +14,10 @@ public static class AvatarUtils
 
     private static readonly string DiscordMediaUrlReplacement =
         "https://media.discordapp.net/attachments/$1/$2/$3.$4?width=256&height=256";
+        
+    // Rewrite time "cachebuster" parameters for randomly generated/chosen avatars with custom URLs.
+    // Number match uses `[1-9][0-9]{0,6}` rather than `[0-9]+` to avoid needing to deal with special cases for zero and limit to reasonable numbers.
+    private static readonly Regex TimePlaceholder = new(@"\{time(?:/(?<divisor>[1-9][0-9]{0,6}))?(?:%(?<modulus>[1-9][0-9]{0,6}))?\}", RegexOptions.IgnoreCase);
 
     public static string? TryRewriteCdnUrl(string? url)
     {
@@ -25,7 +29,23 @@ public static class AvatarUtils
         if (match.Groups["query"].Success)
             newUrl += "&" + match.Groups["query"].Value;
 
+        newUrl = TimePlaceholder.Replace(newUrl, ProcessTimePlaceholder);
+
         return newUrl;
+    }
+    
+    private static string? ProcessTimePlaceholder(Match m) {
+        // Minutes are the maximum accuracy to avoid too much cache thrashing
+        // AND with the maximum positive value so it's always positive (as if this code will exist long enough for the 64-bit signed unix time to go negative...)
+        var time = (DateTimeOffset.UtcNow.ToUnixTimeSeconds()/60)&Int64.MaxValue;
+
+        if (m.Groups["divisor"].Success)
+            time /= Int32.Parse(m.Groups["divisor"].Value); // as above - guaranteed to not throw and be > 0
+
+        if (m.Groups["modulus"].Success)
+            time %= Int32.Parse(m.Groups["modulus"].Value);
+
+        return time.ToString();
     }
 
     public static bool IsDiscordCdnUrl(string? url) => url != null && DiscordCdnUrl.Match(url).Success;

--- a/PluralKit.Bot/Utils/AvatarUtils.cs
+++ b/PluralKit.Bot/Utils/AvatarUtils.cs
@@ -14,10 +14,6 @@ public static class AvatarUtils
 
     private static readonly string DiscordMediaUrlReplacement =
         "https://media.discordapp.net/attachments/$1/$2/$3.$4?width=256&height=256";
-        
-    // Rewrite time "cachebuster" parameters for randomly generated/chosen avatars with custom URLs.
-    // Number match uses `[1-9][0-9]{0,6}` rather than `[0-9]+` to avoid needing to deal with special cases for zero and limit to reasonable numbers.
-    private static readonly Regex TimePlaceholder = new(@"\{time(?:/(?<divisor>[1-9][0-9]{0,6}))?(?:%(?<modulus>[1-9][0-9]{0,6}))?\}", RegexOptions.IgnoreCase);
 
     public static string? TryRewriteCdnUrl(string? url)
     {
@@ -29,23 +25,7 @@ public static class AvatarUtils
         if (match.Groups["query"].Success)
             newUrl += "&" + match.Groups["query"].Value;
 
-        newUrl = TimePlaceholder.Replace(newUrl, ProcessTimePlaceholder);
-
         return newUrl;
-    }
-    
-    private static string? ProcessTimePlaceholder(Match m) {
-        // Minutes are the maximum accuracy to avoid too much cache thrashing
-        // AND with the maximum positive value so it's always positive (as if this code will exist long enough for the 64-bit signed unix time to go negative...)
-        var time = (DateTimeOffset.UtcNow.ToUnixTimeSeconds()/60)&Int64.MaxValue;
-
-        if (m.Groups["divisor"].Success)
-            time /= Int32.Parse(m.Groups["divisor"].Value); // as above - guaranteed to not throw and be > 0
-
-        if (m.Groups["modulus"].Success)
-            time %= Int32.Parse(m.Groups["modulus"].Value);
-
-        return time.ToString();
     }
 
     public static bool IsDiscordCdnUrl(string? url) => url != null && DiscordCdnUrl.Match(url).Success;

--- a/PluralKit.Core/Utils/MiscUtils.cs
+++ b/PluralKit.Core/Utils/MiscUtils.cs
@@ -4,7 +4,6 @@ namespace PluralKit.Core;
 
 public static class MiscUtils
 {
-
     // discord mediaproxy URLs used to be stored directly in the database, so now we cleanup image urls before using them outside of proxying
     private static readonly Regex MediaProxyUrl =
         new(

--- a/PluralKit.Core/Utils/MiscUtils.cs
+++ b/PluralKit.Core/Utils/MiscUtils.cs
@@ -12,7 +12,7 @@ public static class MiscUtils
     private static readonly string DiscordCdnReplacement = "https://cdn.discordapp.com/attachments/$1/$2/$3.$4";
 
     // Rewrite time "cachebuster" parameters for randomly generated/chosen avatars with custom URLs.
-    private static readonly Regex TimePlaceholder = new(@"\{(time(?:stamp|_(?:1m|5m|30m|1h|6h|1d)))\}");
+    private static readonly Regex TimePlaceholder = new(@"(?:\{|%7B)(time(?:stamp|_(?:1m|5m|30m|1h|6h|1d)))(?:\}|%7D)");
     private const Int64 TimeAccuracy = 60;
 
     public static bool TryMatchUri(string input, out Uri uri)

--- a/PluralKit.Core/Utils/MiscUtils.cs
+++ b/PluralKit.Core/Utils/MiscUtils.cs
@@ -4,7 +4,7 @@ namespace PluralKit.Core;
 
 public static class MiscUtils
 {
-	
+
     // discord mediaproxy URLs used to be stored directly in the database, so now we cleanup image urls before using them outside of proxying
     private static readonly Regex MediaProxyUrl =
         new(
@@ -52,7 +52,7 @@ public static class MiscUtils
             case "time_1h": time /= 60*60; break;
             case "time_6h": time /= 6*60*60; break;
             case "time_1d": time /= 24*60*60; break;
-		}
+        }
 
         return time.ToString();
     }

--- a/PluralKit.Core/Utils/MiscUtils.cs
+++ b/PluralKit.Core/Utils/MiscUtils.cs
@@ -4,12 +4,17 @@ namespace PluralKit.Core;
 
 public static class MiscUtils
 {
+	
     // discord mediaproxy URLs used to be stored directly in the database, so now we cleanup image urls before using them outside of proxying
     private static readonly Regex MediaProxyUrl =
         new(
             @"^https?://media.discordapp.net/attachments/(\d{17,19})/(\d{17,19})/([^/\\&\?]+)\.(png|jpg|jpeg|webp)(\?.*)?$");
 
     private static readonly string DiscordCdnReplacement = "https://cdn.discordapp.com/attachments/$1/$2/$3.$4";
+
+    // Rewrite time "cachebuster" parameters for randomly generated/chosen avatars with custom URLs.
+    private static readonly Regex TimePlaceholder = new(@"\{(time(?:stamp|_(?:1m|5m|30m|1h|6h|1d)))\}");
+    private const Int64 TimeAccuracy = 60;
 
     public static bool TryMatchUri(string input, out Uri uri)
     {
@@ -32,5 +37,24 @@ public static class MiscUtils
     }
 
     public static string? TryGetCleanCdnUrl(this string? url) =>
-        url == null ? null : MediaProxyUrl.Replace(url, DiscordCdnReplacement);
+        url == null ? null : TimePlaceholder.Replace(MediaProxyUrl.Replace(url, DiscordCdnReplacement), ProcessTimePlaceholder);
+
+    private static string? ProcessTimePlaceholder(Match m) {
+        // Limit maximum accuracy to avoid too much cache thrashing, multiply for standard-ish Unix time
+        // AND with the maximum positive value so it's always positive (as if this code will exist long enough for the 64-bit signed unix time to go negative...)
+        var time = ((DateTimeOffset.UtcNow.ToUnixTimeSeconds()/TimeAccuracy)*TimeAccuracy)&Int64.MaxValue;
+        
+        switch (m.Groups[1].Value) {
+            case "timestamp": break;
+            case "time_1m": time /= 60; break;
+            case "time_5m": time /= 60*5; break;
+            case "time_30m": time /= 60*30; break;
+            case "time_1h": time /= 60*60; break;
+            case "time_6h": time /= 6*60*60; break;
+            case "time_1d": time /= 24*60*60; break;
+		}
+
+        return time.ToString();
+    }
+
 }


### PR DESCRIPTION
<img src="https://files.y2k.diy/av/circle/una.webp" width="40" height="40" align="center"> <b>Una</b> commented:

This was briefly discussed in the Discord. This is prototype quality and our first time writing C♯.

I chose this implementation route as it's stateless and requires no new commands or extra data to pass around. ~~AvatarUtils seemed like an appropriate place to put this.~~

I've confirmed the code works with a few sample URLs in a miniature test harness but am not able to run this in the full bot right now.

<del>

The syntax implemented here is as follows:

* `{time}` to just dump minutes since the Unix epoch into the URL
* `{time/N}` to divide it by N (i.e. updates every N minutes)
* `{time%N}` to require it to be within a certain range
* `{time/N%M}` — the combination thereof

</del>

This allows custom URL avatars to regularly change, without relying on the implementation details of when and how Discord refreshes avatars. It is, in essence, a cachebuster parameter, and such behavior is trivially provided by `?ts={timestamp}` — ~~static avatar cycling can be accomplished with e.g. `/avatars/membername/{time%5}.png` to select from 5 different avatars (0, 1, 2, 3, and 4.png).~~

~~I've crafted the regex so error handling isn't necessary. The maximum value for the divisor and modulus parameters with this regex is `9999999`, which comfortably fits in an Int32, and the regex will not match a lone `0`.~~

Open questions:
* ~~Is this an appropriate place to put this logic? This method does not seem to be called for e.g. embed cards — does that make this a bad place for this logic, or mean the embed generators need updated?~~ Moved to TryGetCleanCdnUrl.
* Should more complex parsing logic be used to prevent having these placeholders outside of the path portion of the URL?
* ~~Is validating the numbers in the regex and not using TryParse scary?~~ Removed parsing of numbers in favor of fixed options.
* How should this be documented?