### PR TITLE
fix(api): per system rate limits for owned resources

### DIFF
--- a/crates/api/src/auth.rs
+++ b/crates/api/src/auth.rs
@@ -1,4 +1,4 @@
-use pluralkit_models::{PKSystem, PrivacyLevel, SystemId};
+use pluralkit_models::{PrivacyLevel, SystemId};
 
 pub const INTERNAL_SYSTEMID_HEADER: &'static str = "x-pluralkit-systemid";
 pub const INTERNAL_APPID_HEADER: &'static str = "x-pluralkit-appid";

--- a/crates/api/src/auth.rs
+++ b/crates/api/src/auth.rs
@@ -31,27 +31,15 @@ impl AuthState {
         self.internal
     }
 
-    pub fn access_level_for(&self, a: &impl Authable) -> PrivacyLevel {
+    pub fn access_level_for(&self, requested_system_id: SystemId) -> PrivacyLevel {
         if self
             .system_id
-            .map(|id| id == a.authable_system_id())
+            .map(|id| id == requested_system_id)
             .unwrap_or(false)
         {
             PrivacyLevel::Private
         } else {
             PrivacyLevel::Public
         }
-    }
-}
-
-// authable trait/impls
-
-pub trait Authable {
-    fn authable_system_id(&self) -> SystemId;
-}
-
-impl Authable for PKSystem {
-    fn authable_system_id(&self) -> SystemId {
-        self.id
     }
 }

--- a/crates/api/src/endpoints/system.rs
+++ b/crates/api/src/endpoints/system.rs
@@ -3,32 +3,24 @@ use pk_macros::api_endpoint;
 use serde_json::{Value, json};
 use sqlx::Postgres;
 
-use pluralkit_models::{PKSystem, PKSystemConfig, PrivacyLevel};
+use pluralkit_models::{PKSystemConfig, PrivacyLevel, SystemId};
 
-use crate::{ApiContext, auth::AuthState, error::fail};
+use crate::{
+    ApiContext,
+    auth::AuthState,
+    error::{PKError, fail},
+    middleware::params::RequestAboutSystem,
+};
 
 #[api_endpoint]
 pub async fn get_system_settings(
     Extension(auth): Extension<AuthState>,
-    Extension(system): Extension<PKSystem>,
+    Extension(system): Extension<RequestAboutSystem>,
     State(ctx): State<ApiContext>,
 ) -> Json<Value> {
-    let access_level = auth.access_level_for(&system);
+    let access_level = auth.access_level_for(system.id);
 
-    let mut config = match sqlx::query_as::<Postgres, PKSystemConfig>(
-        "select * from system_config where system = $1",
-    )
-    .bind(system.id)
-    .fetch_optional(&ctx.db)
-    .await
-    {
-        Ok(Some(config)) => config,
-        Ok(None) => fail!(
-            system = system.id,
-            "failed to find system config for existing system"
-        ),
-        Err(err) => fail!(?err, "failed to query system config"),
-    };
+    let mut config = lookup_config(system.id, &ctx.db).await?;
 
     // fix this
     if config.name_format.is_none() {
@@ -49,4 +41,23 @@ pub async fn get_system_settings(
             "name_format": config.name_format,
         }),
     }))
+}
+
+async fn lookup_config(
+    system_id: SystemId,
+    db: &sqlx::Pool<Postgres>,
+) -> Result<PKSystemConfig, PKError> {
+    let db_result =
+        sqlx::query_as::<Postgres, PKSystemConfig>("select * from system_config where system = $1")
+            .bind(system_id)
+            .fetch_optional(db)
+            .await;
+    match db_result {
+        Ok(Some(config)) => Ok(config),
+        Ok(None) => fail!(
+            system = system_id,
+            "failed to find system config for existing system"
+        ),
+        Err(err) => fail!(?err, "failed to query system config"),
+    }
 }

--- a/crates/api/src/error.rs
+++ b/crates/api/src/error.rs
@@ -84,3 +84,7 @@ macro_rules! define_error {
 
 define_error! { GENERIC_BAD_REQUEST, StatusCode::BAD_REQUEST, 0, "400: Bad Request" }
 define_error! { GENERIC_SERVER_ERROR, StatusCode::INTERNAL_SERVER_ERROR, 0, "500: Internal Server Error" }
+define_error! { SYSTEM_NOT_FOUND, StatusCode::NOT_FOUND, 20001, "System not found." }
+define_error! { MEMBER_NOT_FOUND, StatusCode::NOT_FOUND, 20002, "Member not found." }
+define_error! { GROUP_NOT_FOUND , StatusCode::NOT_FOUND, 20004, "Group not found." }
+define_error! { SWITCH_NOT_FOUND, StatusCode::NOT_FOUND, 20007, "Switch not found." }

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -127,6 +127,9 @@ fn router(ctx: ApiContext) -> Router {
         .route("/v2/members/{member_id}/oembed.json", get(rproxy))
         .route("/v2/groups/{group_id}/oembed.json", get(rproxy))
 
+        // according to https://docs.rs/axum/latest/axum/middleware/index.html#ordering
+        // when using repeated .layer(...), the layers are applied bottom to top, then the route handles the request,
+        // and finally the second part of the layer is applies top to bottom
         .layer(axum::middleware::from_fn_with_state(
             if config.api().use_ratelimiter {
                 Some(ctx.redis.clone())

--- a/crates/api/src/middleware/params.rs
+++ b/crates/api/src/middleware/params.rs
@@ -6,12 +6,18 @@ use axum::{
     routing::url_params::UrlParams,
 };
 
-use sqlx::{Postgres, types::Uuid};
+use sqlx::{Postgres, prelude::FromRow, types::Uuid};
 use tracing::error;
 
 use crate::auth::AuthState;
 use crate::{ApiContext, util::json_err};
-use pluralkit_models::PKSystem;
+use pluralkit_models::SystemId;
+
+/// The system about which the current request is
+#[derive(Clone, FromRow)]
+pub struct RequestAboutSystem {
+    pub id: SystemId,
+}
 
 // move this somewhere else
 fn parse_hid(hid: &str) -> String {
@@ -52,69 +58,36 @@ pub async fn params(State(ctx): State<ApiContext>, mut req: Request, next: Next)
                         .into();
                     };
 
-                    match sqlx::query_as::<Postgres, PKSystem>(
-                        "select * from systems where id = $1",
-                    )
-                    .bind(system_id)
-                    .fetch_optional(&ctx.db)
-                    .await
-                    {
-                        Ok(Some(system)) => {
-                            req.extensions_mut().insert(system);
-                        }
-                        Ok(None) => {
-                            error!(
-                                ?system_id,
-                                "could not find previously authenticated system in db"
-                            );
-                            return json_err(
-                                StatusCode::INTERNAL_SERVER_ERROR,
-                                r#"{"message": "500: Internal Server Error", "code": 0}"#
-                                    .to_string(),
-                            );
-                        }
-                        Err(err) => {
-                            error!(
-                                ?err,
-                                "failed to query previously authenticated system in db"
-                            );
-                            return json_err(
-                                StatusCode::INTERNAL_SERVER_ERROR,
-                                r#"{"message": "500: Internal Server Error", "code": 0}"#
-                                    .to_string(),
-                            );
-                        }
-                    }
+                    req.extensions_mut()
+                        .insert(RequestAboutSystem { id: system_id });
                 }
                 id => {
-                    println!("a {id}");
-                    match match Uuid::parse_str(id) {
-                        Ok(uuid) => sqlx::query_as::<Postgres, PKSystem>(
-                            "select * from systems where uuid = $1",
+                    println!("params.rs. lookup {id}");
+                    let query = match Uuid::parse_str(id) {
+                        Ok(uuid) => sqlx::query_as::<Postgres, RequestAboutSystem>(
+                            "select id from systems where uuid = $1",
                         )
                         .bind(uuid),
                         Err(_) => match id.parse::<i64>() {
-                            Ok(parsed) => sqlx::query_as::<Postgres, PKSystem>(
-                                "select * from systems where id = (select system from accounts where uid = $1)"
+                            Ok(parsed) => sqlx::query_as::<Postgres, RequestAboutSystem>(
+                                "select id from systems where id = (select system from accounts where uid = $1)"
                             )
                             .bind(parsed),
-                            Err(_) => sqlx::query_as::<Postgres, PKSystem>(
-                                "select * from systems where hid = $1",
+                            Err(_) => sqlx::query_as::<Postgres, RequestAboutSystem>(
+                                "select id from systems where hid = $1",
                             )
                             .bind(parse_hid(id))
                         },
-                    }
-                    .fetch_optional(&ctx.db)
-                    .await
-                    {
-                        Ok(Some(system)) => {
-                            req.extensions_mut().insert(system);
+                    };
+                    match query.fetch_optional(&ctx.db).await {
+                        Ok(Some(request_system)) => {
+                            req.extensions_mut().insert(request_system);
                         }
                         Ok(None) => {
                             return json_err(
                                 StatusCode::NOT_FOUND,
                                 r#"{"message":"System not found.","code":20001}"#.to_string(),
-                            )
+                            );
                         }
                         Err(err) => {
                             error!(?err, ?id, "failed to query system from path in db");

--- a/crates/api/src/middleware/params.rs
+++ b/crates/api/src/middleware/params.rs
@@ -2,22 +2,22 @@ use axum::{
     extract::{Request, State},
     http::StatusCode,
     middleware::Next,
-    response::Response,
+    response::{IntoResponse, Response},
     routing::url_params::UrlParams,
 };
+use sqlx::{Postgres, types::Uuid};
+use tracing::{error, info};
 
-use sqlx::{Postgres, prelude::FromRow, types::Uuid};
-use tracing::error;
-
-use crate::auth::AuthState;
-use crate::{ApiContext, util::json_err};
-use pluralkit_models::SystemId;
-
-/// The system about which the current request is
-#[derive(Clone, FromRow)]
-pub struct RequestAboutSystem {
-    pub id: SystemId,
-}
+use crate::{
+    ApiContext,
+    auth::AuthState,
+    error::{
+        GENERIC_BAD_REQUEST, GENERIC_SERVER_ERROR, GROUP_NOT_FOUND, MEMBER_NOT_FOUND, PKError,
+        SWITCH_NOT_FOUND, SYSTEM_NOT_FOUND,
+    },
+    util::json_err,
+};
+use pluralkit_models::{GroupId, MemberId, SwitchId, SystemId};
 
 // move this somewhere else
 fn parse_hid(hid: &str) -> String {
@@ -42,71 +42,249 @@ pub async fn params(State(ctx): State<ApiContext>, mut req: Request, next: Next)
     };
 
     for (key, value) in pms {
+        let id_ref = value.as_str();
         match key.as_ref() {
-            "system_id" => match value.as_str() {
-                "@me" => {
-                    let Some(system_id) = req
-                        .extensions()
-                        .get::<AuthState>()
-                        .expect("missing auth state")
-                        .system_id()
-                    else {
+            "system_id" if id_ref == "@me" => {
+                let system_id = match req
+                    .extensions()
+                    .get::<AuthState>()
+                    .expect("missing auth state")
+                    .system_id()
+                {
+                    Some(system_id) => system_id,
+                    _ => {
                         return json_err(
-                            StatusCode::UNAUTHORIZED,
-                            r#"{"message":"401: Missing or invalid Authorization header","code": 0}"#.to_string(),
-                        )
-                        .into();
-                    };
+                                        StatusCode::UNAUTHORIZED,
+                                        r#"{"message":"401: Missing or invalid Authorization header","code": 0}"#
+                                            .to_string(),
+                                    )
+                                    .into();
+                    }
+                };
 
+                req.extensions_mut()
+                    .insert(RequestAboutSystem { id: system_id });
+            }
+            "system_id" => match resolve_system_id(id_ref, &ctx.db).await {
+                Ok(system_id) => {
                     req.extensions_mut()
                         .insert(RequestAboutSystem { id: system_id });
                 }
-                id => {
-                    println!("params.rs. lookup {id}");
-                    let query = match Uuid::parse_str(id) {
-                        Ok(uuid) => sqlx::query_as::<Postgres, RequestAboutSystem>(
-                            "select id from systems where uuid = $1",
-                        )
-                        .bind(uuid),
-                        Err(_) => match id.parse::<i64>() {
-                            Ok(parsed) => sqlx::query_as::<Postgres, RequestAboutSystem>(
-                                "select id from systems where id = (select system from accounts where uid = $1)"
-                            )
-                            .bind(parsed),
-                            Err(_) => sqlx::query_as::<Postgres, RequestAboutSystem>(
-                                "select id from systems where hid = $1",
-                            )
-                            .bind(parse_hid(id))
-                        },
-                    };
-                    match query.fetch_optional(&ctx.db).await {
-                        Ok(Some(request_system)) => {
-                            req.extensions_mut().insert(request_system);
-                        }
-                        Ok(None) => {
-                            return json_err(
-                                StatusCode::NOT_FOUND,
-                                r#"{"message":"System not found.","code":20001}"#.to_string(),
-                            );
-                        }
-                        Err(err) => {
-                            error!(?err, ?id, "failed to query system from path in db");
-                            return json_err(
-                                StatusCode::INTERNAL_SERVER_ERROR,
-                                r#"{"message": "500: Internal Server Error", "code": 0}"#
-                                    .to_string(),
-                            );
-                        }
-                    }
-                }
+                Err(e) => return e.into_response(),
             },
-            "member_id" => {}
-            "group_id" => {}
-            "switch_id" => {}
-            "guild_id" => {}
+            "member_id" => match resolve_member_id(id_ref, &ctx.db).await {
+                Ok((member_id, system_id)) => {
+                    req.extensions_mut().insert(RequestAboutMember {
+                        id: member_id,
+                        system: system_id,
+                    });
+                    req.extensions_mut()
+                        .insert(RequestAboutSystem { id: system_id });
+                }
+                Err(e) => return e.into_response(),
+            },
+            "group_id" => match resolve_group_id(id_ref, &ctx.db).await {
+                Ok((group_id, system_id)) => {
+                    req.extensions_mut().insert(RequestAboutGroup {
+                        id: group_id,
+                        system: system_id,
+                    });
+                    req.extensions_mut()
+                        .insert(RequestAboutSystem { id: system_id });
+                }
+                Err(e) => return e.into_response(),
+            },
+            "switch_id" => match resolve_switch_id(id_ref, &ctx.db).await {
+                Ok((switch_id, system_id)) => {
+                    req.extensions_mut().insert(RequestAboutSwitch {
+                        id: switch_id,
+                        system: system_id,
+                    });
+                    req.extensions_mut()
+                        .insert(RequestAboutSystem { id: system_id });
+                }
+                Err(e) => return e.into_response(),
+            },
             _ => {}
         }
     }
 
     next.run(req).await
+}
+
+// resolve and lookup owning system from reference
+
+async fn resolve_system_id(id_ref: &str, db: &sqlx::Pool<Postgres>) -> Result<SystemId, PKError> {
+    let system_ref = SystemRef::from(id_ref);
+    info!(?system_ref, ?id_ref, "resolving system id");
+
+    // use (SystemId,) instread of SystemId here, as otherwise sqlx doesn't find the postgres trait impl
+    let row: Option<(SystemId,)> = match system_ref {
+        SystemRef::Uuid(u) => sqlx::query_as("select id from systems where uuid = $1")
+            .bind(u)
+            .fetch_optional(db)
+            .await
+            .map_err(|err| {
+                error!(?err, ?id_ref, "failed to query system by uuid from db");
+                GENERIC_SERVER_ERROR
+            })?,
+        SystemRef::DiscordUid(uid) => sqlx::query_as("select system from accounts where uid = $1")
+            .bind(uid)
+            .fetch_optional(db)
+            .await
+            .map_err(|err| {
+                error!(
+                    ?err,
+                    ?id_ref,
+                    "failed to query system by discord uid from db"
+                );
+                GENERIC_SERVER_ERROR
+            })?,
+        SystemRef::Hid(hid) => sqlx::query_as("select id from systems where hid = $1")
+            .bind(&hid)
+            .fetch_optional(db)
+            .await
+            .map_err(|err| {
+                error!(?err, ?id_ref, "failed to query system by hid from db");
+                GENERIC_SERVER_ERROR
+            })?,
+    };
+
+    row.map(|id| id.0).ok_or(SYSTEM_NOT_FOUND)
+}
+
+async fn resolve_member_id(
+    id_ref: &str,
+    db: &sqlx::Pool<Postgres>,
+) -> Result<(MemberId, SystemId), PKError> {
+    let member_ref = if let Ok(uuid) = Uuid::parse_str(id_ref) {
+        MemberRef::Uuid(uuid)
+    } else {
+        MemberRef::Hid(parse_hid(id_ref))
+    };
+    info!(?member_ref, ?id_ref, "resolving member id");
+
+    let row = match member_ref {
+        MemberRef::Uuid(u) => sqlx::query_as("select id, system from members where uuid = $1")
+            .bind(u)
+            .fetch_optional(db)
+            .await
+            .map_err(|err| {
+                error!(?err, ?id_ref, "failed to query member by uuid from db");
+                GENERIC_SERVER_ERROR
+            })?,
+        MemberRef::Hid(hid) => sqlx::query_as("select id, system from members where hid = $1")
+            .bind(hid)
+            .fetch_optional(db)
+            .await
+            .map_err(|err| {
+                error!(?err, ?id_ref, "failed to query member by hid from db");
+                GENERIC_SERVER_ERROR
+            })?,
+    };
+
+    row.ok_or(MEMBER_NOT_FOUND)
+}
+
+async fn resolve_group_id(
+    id_ref: &str,
+    db: &sqlx::Pool<Postgres>,
+) -> Result<(GroupId, SystemId), PKError> {
+    let group_ref = if let Ok(uuid) = Uuid::parse_str(id_ref) {
+        GroupRef::Uuid(uuid)
+    } else {
+        GroupRef::Hid(parse_hid(id_ref))
+    };
+    info!(?group_ref, ?id_ref, "resolving group id");
+
+    let row = match group_ref {
+        GroupRef::Uuid(u) => sqlx::query_as("select id, system from groups where uuid = $1")
+            .bind(u)
+            .fetch_optional(db)
+            .await
+            .map_err(|err| {
+                error!(?err, ?id_ref, "failed to query group by uuid from db");
+                GENERIC_SERVER_ERROR
+            })?,
+        GroupRef::Hid(hid) => sqlx::query_as("select id, system from groups where hid = $1")
+            .bind(hid)
+            .fetch_optional(db)
+            .await
+            .map_err(|err| {
+                error!(?err, ?id_ref, "failed to query group by hid from db");
+                GENERIC_SERVER_ERROR
+            })?,
+    };
+
+    row.ok_or(GROUP_NOT_FOUND)
+}
+
+async fn resolve_switch_id(
+    id_ref: &str,
+    db: &sqlx::Pool<Postgres>,
+) -> Result<(SwitchId, SystemId), PKError> {
+    let uuid = Uuid::parse_str(id_ref).map_err(|_| GENERIC_BAD_REQUEST)?;
+    info!(?uuid, ?id_ref, "resolving switch id");
+
+    let row = sqlx::query_as("select id, system from switches where uuid = $1")
+        .bind(uuid)
+        .fetch_optional(db)
+        .await
+        .map_err(|err| {
+            error!(?err, ?id_ref, "failed to query switch by uuid from db");
+            GENERIC_SERVER_ERROR
+        })?;
+
+    row.ok_or(SWITCH_NOT_FOUND)
+}
+
+#[derive(Clone, Debug)]
+pub struct RequestAboutSystem {
+    pub id: SystemId,
+}
+
+#[derive(Clone, Debug)]
+pub struct RequestAboutMember {
+    pub id: MemberId,
+    pub system: SystemId,
+}
+
+#[derive(Clone, Debug)]
+pub struct RequestAboutGroup {
+    pub id: GroupId,
+    pub system: SystemId,
+}
+
+#[derive(Clone, Debug)]
+pub struct RequestAboutSwitch {
+    pub id: SwitchId,
+    pub system: SystemId,
+}
+
+#[derive(Debug)]
+enum SystemRef {
+    Uuid(Uuid),
+    DiscordUid(i64),
+    Hid(String),
+}
+
+impl SystemRef {
+    fn from(s: &str) -> Self {
+        let uuid_opt = Uuid::parse_str(s).map(SystemRef::Uuid).ok();
+        let discord_opt = s.parse::<i64>().map(SystemRef::DiscordUid).ok();
+        let hid = SystemRef::Hid(parse_hid(s));
+        uuid_opt.or(discord_opt).unwrap_or(hid)
+    }
+}
+
+#[derive(Debug)]
+enum MemberRef {
+    Uuid(Uuid),
+    Hid(String),
+}
+
+#[derive(Debug)]
+enum GroupRef {
+    Uuid(Uuid),
+    Hid(String),
 }

--- a/crates/api/src/middleware/ratelimit.rs
+++ b/crates/api/src/middleware/ratelimit.rs
@@ -1,6 +1,7 @@
 use std::time::{Duration, SystemTime};
 
 use axum::{
+    body::Body,
     extract::{MatchedPath, Request, State},
     http::{HeaderValue, Method, StatusCode},
     middleware::Next,
@@ -12,6 +13,7 @@ use tracing::{debug, error, info};
 
 use crate::{
     auth::AuthState,
+    middleware::params::RequestAboutSystem,
     util::{header_or_unknown, json_err},
 };
 
@@ -76,7 +78,7 @@ pub async fn do_request_ratelimited(
         // todo: make x-ratelimit-scope actually meaningful
 
         // hack: for now, we only have one "registered app", so we hardcode the app id
-        let rlimit = if let Some(app_id) = auth.app_id()
+        let rate_limit_type = if let Some(app_id) = auth.app_id()
             && app_id == 1
         {
             RatelimitType::TempCustom
@@ -88,16 +90,14 @@ pub async fn do_request_ratelimited(
             RatelimitType::GenericUpdate
         };
 
+        let rate_limit_by_system_or_source_ip =
+            system_id_if_resource_owned_by_system(auth, &request)
+                .unwrap_or_else(|| source_ip.to_string());
+
         let rl_key = format!(
             "{}:{}",
-            if let Some(system_id) = auth.system_id()
-                && matches!(rlimit, RatelimitType::GenericUpdate)
-            {
-                system_id.to_string()
-            } else {
-                source_ip.to_string()
-            },
-            rlimit.key()
+            rate_limit_by_system_or_source_ip,
+            rate_limit_type.key()
         );
 
         let period = 1; // seconds
@@ -135,7 +135,7 @@ pub async fn do_request_ratelimited(
             .evalsha::<(i32, String, u64), String, Vec<String>, Vec<i32>>(
                 LUA_SCRIPT_SHA.to_string(),
                 vec![rl_key.clone()],
-                vec![rlimit.rate(), period, cost],
+                vec![rate_limit_type.rate(), period, cost],
             )
             .await;
 
@@ -156,7 +156,7 @@ pub async fn do_request_ratelimited(
                         StatusCode::TOO_MANY_REQUESTS,
                         format!(
                             r#"{{"message":"429: too many requests","retry_after":{retry_after},"scope":"{}","code":0}}"#,
-                            rlimit.key(),
+                            rate_limit_type.key(),
                         ),
                     )
                 };
@@ -171,11 +171,12 @@ pub async fn do_request_ratelimited(
                 let headers = response.headers_mut();
                 headers.insert(
                     "X-RateLimit-Scope",
-                    HeaderValue::from_str(rlimit.key().as_str()).expect("invalid header value"),
+                    HeaderValue::from_str(rate_limit_type.key().as_str())
+                        .expect("invalid header value"),
                 );
                 headers.insert(
                     "X-RateLimit-Limit",
-                    HeaderValue::from_str(format!("{}", rlimit.rate()).as_str())
+                    HeaderValue::from_str(format!("{}", rate_limit_type.rate()).as_str())
                         .expect("invalid header value"),
                 );
                 headers.insert(
@@ -202,4 +203,15 @@ pub async fn do_request_ratelimited(
     }
 
     next.run(request).await
+}
+
+fn system_id_if_resource_owned_by_system(
+    auth: &AuthState,
+    request: &Request<Body>,
+) -> Option<String> {
+    let requested_system_id = request.extensions().get::<RequestAboutSystem>();
+    match (auth.system_id(), requested_system_id) {
+        (Some(auth_id), Some(req_id)) if auth_id == req_id.id => Some(auth_id.to_string()),
+        _ => None,
+    }
 }

--- a/crates/models/src/group.rs
+++ b/crates/models/src/group.rs
@@ -1,0 +1,7 @@
+pub type GroupId = i32;
+
+#[derive(Debug, Clone)]
+pub enum GroupRef {
+    Uuid(uuid::Uuid),
+    Hid(String),
+}

--- a/crates/models/src/lib.rs
+++ b/crates/models/src/lib.rs
@@ -1,14 +1,16 @@
 mod _util;
 
-macro_rules! model {
-    ($n:ident) => {
-        mod $n;
-        pub use $n::*;
-    };
-}
+mod group;
+mod member;
+mod switch;
+mod system;
+mod system_config;
 
-model!(system);
-model!(system_config);
+pub use group::*;
+pub use member::*;
+pub use switch::*;
+pub use system::*;
+pub use system_config::*;
 
 #[derive(serde::Serialize, Debug, Clone)]
 #[serde(rename_all = "snake_case")]

--- a/crates/models/src/member.rs
+++ b/crates/models/src/member.rs
@@ -1,0 +1,8 @@
+
+pub type MemberId = i32;
+
+#[derive(Debug, Clone)]
+pub enum MemberRef {
+    Uuid(uuid::Uuid),
+    Hid(String),
+}

--- a/crates/models/src/switch.rs
+++ b/crates/models/src/switch.rs
@@ -1,0 +1,6 @@
+pub type SwitchId = i32;
+
+#[derive(Debug, Clone)]
+pub enum SwitchRef {
+    Uuid(uuid::Uuid),
+}

--- a/crates/models/src/system.rs
+++ b/crates/models/src/system.rs
@@ -8,6 +8,13 @@ use crate::PrivacyLevel;
 // todo: fix this
 pub type SystemId = i32;
 
+#[derive(Debug, Clone)]
+pub enum SystemRef {
+    Uuid(uuid::Uuid),
+    DiscordAccountUid(i64),
+    Hid(String),
+}
+
 #[pk_model]
 struct System {
     id: SystemId,

--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -50,6 +50,11 @@ PluralKit__Bot__HttpCacheUrl="localhost:5000"
 ```
 
 1. Clone the repository: `git clone --recurse-submodules https://github.com/PluralKit/PluralKit`
+2. Head over to `https://discord.com/developers/applications` and create a new application:
+	* Installation > Set Guild Install scopes to applications.commands and bot and permissions to Administrator
+	* OAuth > Copy OAuth client id+secret
+	* Bot > Copy bot token. Activate Presence + Server Members + Message Content Intents
+3. Create a test discord server you own and invite the app to it via the application install link
 2. Create a `.env` configuration file in the `PluralKit` directory *(see above)*
 3. Build and run: `nix run .#dev`
 	- This will download the dependencies, build, and run PluralKit

--- a/flake.nix
+++ b/flake.nix
@@ -87,7 +87,7 @@
           # };
 
           # TODO: expose other rust packages after it's verified they build and work properly
-          packages = lib.genAttrs ["gateway"] (name: rustOutputs.${name}.packages.release);
+          packages = lib.genAttrs ["gateway" "api"] (name: rustOutputs.${name}.packages.release);
           # TODO: package the bot itself (dotnet)
 
           devShells = {
@@ -193,6 +193,7 @@
                   # TODO: add liveness check
                   ready_log_line = "Received Ready";
                 };
+
                 ### migrations ###
                 pluralkit-migrate-init = mkServiceInitProcess {
                   name = "migrate";
@@ -209,6 +210,7 @@
                   depends_on.postgres.condition = "process_healthy";
                   depends_on.pluralkit-migrate-init.condition = "process_completed_successfully";
                 };
+
                 ### gateway ###
                 pluralkit-gateway-init = mkServiceInitProcess {
                   name = "gateway";
@@ -237,6 +239,29 @@
                   readiness_probe.exec.command = procCfg.pluralkit-gateway.liveness_probe.exec.command;
                   readiness_probe.period_seconds = 5;
                   readiness_probe.initial_delay_seconds = 3;
+                };
+                
+                ### api ###
+                pluralkit-api-init = mkServiceInitProcess {
+                  name = "api";
+                };
+                pluralkit-api = {
+                  command = pkgs.writeShellApplication {
+                    name = "pluralkit-api";
+                    runtimeInputs = with pkgs; [
+                      coreutils
+                      curl
+                      gnugrep
+                    ];
+                    text = ''
+                      ${sourceDotenv}
+                      set -x
+                      exec target/debug/api
+                    '';
+                  };
+                  depends_on.postgres.condition = "process_healthy";
+                  depends_on.redis.condition = "process_healthy";
+                  depends_on.pluralkit-api-init.condition = "process_completed_successfully";
                 };
                 # TODO: add the rest of the services
               };


### PR DESCRIPTION
The basic code for checking against the endpoint path. It should work for `/v2/systems/*` resources. This was shortly discussed on discord. I haven't run and manually tested this code locally yet though.

My biggest questions is that the other endpoints of resources owned by the system are not properly rate-limited by the desired new approach. Specifically, we also want requests on groups and members and switches to be rate-limited by the owning system, if the authentication is via an owning system.

However, resolution of the system in question ONLY happens for the systemRef in the endpoint params (due to it being able to me `@me` and variations): https://github.com/PluralKit/PluralKit/blob/main/crates/api/src/middleware/params.rs#L39 When other params such as member_id, group_id, etc. are passed, they're not used to lookup the owning system.

If I understand correctly, it would just be simply SQL queries against the DB to read who ownes this and then insert it into the request extensions (as we do it for the system already).

What do you folks think?

I'm aware that we have code duplication of this lookup logic in rust as well as the C# part, but I don't think this can be avoided (or is a big issue IMO).