### PR TITLE
flake: Add postgresql to devShell and set default variables

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -11,11 +11,16 @@
       rustOutputs = config.nci.outputs;
       rustDevshell = rustOutputs."pluralkit-services".devShell;
 
-      commonTools = with pkgs; [ nixd ];
+      commonTools = with pkgs; [
+        nixd
+        postgresql
+      ];
       withCommon =
         shell:
         shell.overrideAttrs (old: {
           nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ commonTools;
+          env.PGHOST = "127.0.0.1";
+          env.PGUSER = "postgres";
         });
 
       docs = pkgs.mkShellNoCC {


### PR DESCRIPTION
Sets `PGHOST` and `PGUSER` in the default devShell so that you can run `psql` without arguments and get a working connection. Also adds the `psql` CLI to the devshell so that it's not needed to be added externally via something like `nix shell`.