### PR TITLE
feat(bot): improve member alias discovery

### DIFF
--- a/PluralKit.Bot/CommandMeta/CommandHelp.cs
+++ b/PluralKit.Bot/CommandMeta/CommandHelp.cs
@@ -127,7 +127,7 @@ public partial class CommandTree
     public static Command[] MemberCommands =
     {
         MemberInfo, MemberNew, MemberRename, MemberDisplayName, MemberServerName, MemberDesc, MemberPronouns,
-        MemberColor, MemberBirthday, MemberProxy, MemberAutoproxy, MemberKeepProxy, MemberTts, MemberGroups, MemberGroupAdd,
+        MemberColor, MemberBirthday, MemberProxy, MemberAlias, MemberAutoproxy, MemberKeepProxy, MemberTts, MemberGroups, MemberGroupAdd,
         MemberGroupRemove, MemberDelete, MemberAvatar, MemberServerAvatar, MemberBannerImage, MemberPrivacy,
         MemberRandom
     };

--- a/PluralKit.Bot/Commands/MemberAlias.cs
+++ b/PluralKit.Bot/Commands/MemberAlias.cs
@@ -7,6 +7,7 @@ public class MemberAlias
     public async Task Alias(Context ctx, PKMember target)
     {
         ctx.CheckSystem().CheckOwnMember(target);
+        var format = ctx.MatchFormat();
 
         // "Sub"command: clear flag
         if (ctx.MatchClear())
@@ -25,12 +26,16 @@ public class MemberAlias
             await ctx.Reply($"{Emojis.Success} Aliases cleared.");
         }
         // "Sub"command: no arguments; will print aliases
-        else if (!ctx.HasNext(false))
+        else if (!ctx.HasNext(false) || format != ReplyFormat.Standard)
         {
-            if (target.Aliases.Count == 0)
+            var aliases = target.Aliases;
+
+            if (aliases.Count == 0)
                 await ctx.Reply("This member does not have any aliases.");
+            else if (format == ReplyFormat.Raw)
+                await ctx.Reply($"This member's aliases are:\n{string.Join("\n", aliases.Select(alias => $"```\n{alias}\n```"))}");
             else
-                await ctx.Reply($"This member's aliases are:\n{string.Join('\n', target.Aliases.Select(a => $"- {a}"))}");
+                await ctx.Reply($"This member's aliases are:\n{string.Join('\n', aliases.Select(alias => $"- {alias}"))}");
         }
         // Subcommand: "add"
         else if (ctx.Match("add", "append"))

--- a/PluralKit.Bot/Services/EmbedService.cs
+++ b/PluralKit.Bot/Services/EmbedService.cs
@@ -371,6 +371,21 @@ public class EmbedService
             headerText += $"\n**Message count:** {member.MessageCount}";
 
         List<MessageComponent> extraData = [];
+        if (member.Aliases.Count > 0 && member.NamePrivacy.CanAccess(ctx))
+        {
+            var aliases = string.Join("\n", member.Aliases);
+            extraData.Add(new MessageComponent
+            {
+                Type = ComponentType.Separator,
+            });
+
+            extraData.Add(new MessageComponent
+            {
+                Type = ComponentType.Text,
+                Content = $"**Aliases:**\n{aliases.Truncate(1024)}",
+            });
+        }
+
         if (member.HasProxyTags && member.ProxyPrivacy.CanAccess(ctx))
         {
             extraData.Add(new MessageComponent
@@ -537,6 +552,11 @@ public class EmbedService
             eb.Field(new Embed.Field("Pronouns", pronouns.Truncate(1024), true));
         if (member.MessageCountFor(ctx) is { } count && count > 0)
             eb.Field(new Embed.Field("Message Count", member.MessageCount.ToString(), true));
+        if (member.Aliases.Count > 0 && member.NamePrivacy.CanAccess(ctx))
+        {
+            var aliases = string.Join("\n", member.Aliases);
+            eb.Field(new Embed.Field("Aliases", aliases.Truncate(1024), true));
+        }
         if (member.HasProxyTags && member.ProxyPrivacy.CanAccess(ctx))
             eb.Field(new Embed.Field("Proxy Tags", member.ProxyTagsString("\n").Truncate(1024), true));
         // --- For when this gets added to the member object itself or however they get added

--- a/PluralKit.Core/Database/Views/DatabaseViewsExt.cs
+++ b/PluralKit.Core/Database/Views/DatabaseViewsExt.cs
@@ -23,9 +23,15 @@ public static class DatabaseViewsExt
         {
             static string Filter(string column) =>
                 $"(position(lower(@filter) in lower(coalesce({column}, ''))) > 0)";
+            static string AliasFilter() =>
+                "(exists (select 1 from unnest(aliases) as alias where position(lower(@filter) in lower(alias)) > 0))";
 
             var nameColumn = opts.Context == LookupContext.ByOwner ? "name" : "public_name";
-            query.Append($" and ({Filter(nameColumn)} or {Filter("display_name")}");
+            var aliases = opts.Context == LookupContext.ByOwner
+                ? AliasFilter()
+                : $"(name_privacy = {(int)PrivacyLevel.Public} and {AliasFilter()})";
+
+            query.Append($" and ({Filter(nameColumn)} or {Filter("display_name")} or {aliases}");
             if (opts.SearchDescription)
             {
                 // We need to account for the possibility of description privacy when searching

--- a/docs/content/command-list.md
+++ b/docs/content/command-list.md
@@ -68,7 +68,7 @@ You can have a space after `pk;`, e.g. `pk;system` and `pk; system` will do the 
 - `pk;system [system] frontpercent [timeframe]` - Shows the aggregated front history of a system within a given time frame.
 - `pk;system [system] list` - Shows a paginated list of a system's members.
 - `pk;system [system] list -full` - Shows a paginated list of a system's members, with increased detail.
-- `pk;find <search term>` - Searches members by name.
+- `pk;find <search term>` - Searches members by name, display name, or alias.
 - `pk;system [system] find <search term>` - (same as above, but for a specific system)
 - `pk;system [system] random [-group]` - Shows the info card of a randomly selected member [or group] in a system.
 - `pk;system [system] id` - Prints a system's id. 


### PR DESCRIPTION
## Summary

- expose aliases on member cards when name privacy permits
- support raw alias-list output and include the command in member help
- include aliases in member-list search without exposing private aliases

## Testing

- `git diff --check`
- manual smoke testing against the development bot